### PR TITLE
Historial de Almorzadores

### DIFF
--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -22,14 +22,14 @@ module Lita
       route(/gracias/i, command: true, help: help_msg(:thanks)) do |response|
         response.reply(t(:yourwelcome, subject: response.user.mention_name))
       end
-      route(/^está?a? (listo|servido) el almuerzo/i, help: help_msg(:lunch_served)) do
+      route(/^est[áa] (listo|servido) el almuerzo/i, help: help_msg(:lunch_served)) do
         message = t(:dinner_is_served)
         notify @assigner.winning_lunchers_list, message
       end
-      route(/qué?e? hay de postre/i, help: help_msg(:dessert)) do |response|
+      route(/qu[ée] hay de postre/i, help: help_msg(:dessert)) do |response|
         response.reply(t(:"todays_dessert#{1 + rand(4)}"))
       end
-      route(/qué?e? hay de almuerzo/i, help: help_msg(:menu)) do |response|
+      route(/qu[ée] hay de almuerzo/i, help: help_msg(:menu)) do |response|
         response.reply(t(:todays_lunch))
       end
       route(/por\sfavor\sconsidera\sa\s([^\s]+)\s(para|en) (el|los) almuerzos?/,
@@ -42,7 +42,7 @@ module Lita
           response.reply(t(:already_considered, subject: mention_name))
         end
       end
-      route(/por\sfavor\sconsidé?e?rame\s(para|en) los almuerzos/i,
+      route(/por\sfavor\sconsid[ée]rame\s(para|en) los almuerzos/i,
         command: true, help: help_msg(:consider_me)) do |response|
         success = @assigner.add_to_lunchers(response.user.mention_name)
         if success
@@ -57,7 +57,7 @@ module Lita
         @assigner.remove_from_lunchers(mention_name)
         response.reply(t(:thanks_for_answering))
       end
-      route(/^sí$|^hoy almuerzo aqu(í|i)$|^si$/i,
+      route(/^s[íi]$|^hoy almuerzo aqu[íi]$/i,
         command: true, help: help_msg(:confirm_yes)) do |response|
         @assigner.add_to_current_lunchers(response.user.mention_name)
         @assigner.add_to_winning_lunchers(response.user.mention_name) if @assigner.already_assigned?
@@ -88,7 +88,7 @@ module Lita
         response.reply("es rica?")
       end
 
-      route(/qui(é|e)nes almuerzan hoy/i, help: help_msg(:show_today_lunchers)) do |response|
+      route(/qui[ée]nes almuerzan hoy/i, help: help_msg(:show_today_lunchers)) do |response|
         unless @assigner.already_assigned?
           response.reply("Aun no lo se pero van #{@assigner.current_lunchers_list.count} interesados.")
           next
@@ -109,7 +109,7 @@ module Lita
         end
       end
 
-      route(/qui(é|e)n(es)? ((cooper(o|ó|aron))|(cag(o|ó|aron))|(qued(o|ó|aron)) afuera) ((del|con el) almuerzo)? (hoy)?\??/i,
+      route(/qui[ée]n(es)? ((cooper(o|ó|aron))|(cag(o|ó|aron))|(qued(o|ó|aron)) afuera) ((del|con el) almuerzo)? (hoy)?\??/i,
         help: help_msg(:show_loosing_lunchers)) do |response|
         unless @assigner.already_assigned?
           response.reply("No lo se, pero van #{@assigner.current_lunchers_list.count} interesados.")
@@ -124,7 +124,7 @@ module Lita
         end
       end
 
-      route(/qui(é|e)nes est(á|a)n considerados para (el|los) almuerzos?/i,
+      route(/qui[ée]nes est[áa]n considerados para (el|los) almuerzos?\??/i,
         help: help_msg(:show_considered)) do |response|
         response.reply(@assigner.lunchers_list.join(', '))
       end
@@ -134,18 +134,18 @@ module Lita
         response.reply("did it boss")
       end
 
-      route(/cu(á|a)nto karma tengo\?/i, command: true) do |response|
+      route(/cu[áa]nto karma tengo\??/i, command: true) do |response|
         user_karma = @assigner.get_karma(response.user.mention_name)
         response.reply("Tienes #{user_karma} puntos de karma, mi padawan.")
       end
 
-      route(/cu(á|a)nto karma tiene ([^\s]+)\?/i, command: true) do |response|
+      route(/cu[áa]nto karma tiene ([^\s]+)\??/i, command: true) do |response|
         user = clean_mention_name(response.matches[0][1])
         user_karma = @assigner.get_karma(user)
         response.reply("@#{user} tiene #{user_karma} puntos de karma.")
       end
 
-      route(/cédele mi puesto a ([^\s]+)/i, command: true) do |response|
+      route(/c[eé]dele mi puesto a ([^\s]+)/i, command: true) do |response|
         unless @assigner.remove_from_winning_lunchers(response.user.mention_name)
           response.reply("no puedes ceder algo que no tienes, amiguito")
           next

--- a/lib/lita/services/lunch_assigner.rb
+++ b/lib/lita/services/lunch_assigner.rb
@@ -64,7 +64,10 @@ module Lita
 
       def persist_winning_lunchers
         sw = Lita::Services::SpreadsheetWriter.new
-        sw.write_new_row([Time.now.strftime("%Y-%m-%d")].concat(winning_lunchers_list))
+        time = Time.now.strftime("%Y-%m-%d")
+        winning_lunchers_list.each do |winner| 
+          sw.write_new_row([time, winner])
+        end
       end
 
       def winning_lunchers_list

--- a/lib/lita/services/lunch_assigner.rb
+++ b/lib/lita/services/lunch_assigner.rb
@@ -66,7 +66,9 @@ module Lita
         sw = Lita::Services::SpreadsheetWriter.new
         time = Time.now.strftime("%Y-%m-%d")
         winning_lunchers_list.each do |winner| 
-          sw.write_new_row([time, winner])
+          user = User.find_by_mention_name(winner) || User.find_by_name(winner)
+          winner_id = user ? user.id : nil
+          sw.write_new_row([time, winner, winner_id])
         end
       end
 

--- a/lib/lita/services/spreadsheet_writer.rb
+++ b/lib/lita/services/spreadsheet_writer.rb
@@ -5,7 +5,8 @@ module Lita
     class SpreadsheetWriter
       def initialize
         @session = GoogleDrive::Session.from_service_account_key(credentials_io)
-        @ws = @session.spreadsheet_by_key(ENV['GOOGLE_SP_KEY']).worksheets[0]
+        @spreadsheet = @session.spreadsheet_by_key(ENV['GOOGLE_SP_KEY'])
+        @ws = @spreadsheet.worksheets[0]
       end
 
       def credentials_io
@@ -22,6 +23,15 @@ module Lita
           client_x509_cert_url: ENV['GOOGLE_SP_CRED_CLIENT_X509_CERT_URL']
         }
         StringIO.new(credentials.to_json)
+      end
+
+      # current selected worksheet
+      def worksheet
+        @ws
+      end
+      
+      def spreadsheet
+        @spreadsheet
       end
 
       def write_new_row(array)

--- a/spec/lita/services/spreadsheet_writer_spec.rb
+++ b/spec/lita/services/spreadsheet_writer_spec.rb
@@ -1,0 +1,55 @@
+
+require "spec_helper"
+require 'pry'
+require 'dotenv/load'
+
+describe Lita::Services::LunchAssigner, lita: true do
+  
+  # Test helper class 
+  # Each new instance now has an isolated worksheet
+  class SpreadsheetWriterTest < Lita::Services::SpreadsheetWriter
+    @@written_files = []
+    def initialize
+      super
+      test_name = "test-#{rand.to_s[-8..-1]}"
+      @ws = @spreadsheet.add_worksheet(test_name)
+      @@written_files << test_name
+    end  
+
+    def self.written_files
+      @@written_files
+    end
+  end
+
+  # Clean up the test worksheets from the drive when done  
+  after(:all) do 
+    spreadsheet = Lita::Services::SpreadsheetWriter.new.spreadsheet
+    worksheets = spreadsheet.worksheets
+    worksheets.select { |w| SpreadsheetWriterTest.written_files.include? w.title }
+              .each(&:delete)
+  end
+  
+  context "on a new empty worksheet" do
+    let!(:spreadsheetWriter) { SpreadsheetWriterTest.new }
+    let!(:spreadsheet) { spreadsheetWriter.spreadsheet }
+    let!(:worksheet) { spreadsheetWriter.worksheet }
+
+    describe "#write_new_row" do
+      context "when given an array with values" do 
+        it "should write the array in the last row, each value in it's own column" do
+          array = [*0..5]
+          write_flag = spreadsheetWriter.write_new_row(array)
+          expect(write_flag).to eq(true)
+          expect(worksheet.rows.last).to eq(array.map(&:to_s))
+        end
+      end
+
+      context "given an empty array" do
+        it "should not write in the worksheet and return false" do 
+          write_flag = spreadsheetWriter.write_new_row([]) 
+          expect(write_flag).to eq(false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Se guarda ahora periodicamente la gente que almorzó en un spreadsheet guardado en google drive, con el formato _dia | nombre | id_

No estoy seguro si la mejor manera de hacer los test es probando directamente en el google drive, pero en todo caso me asegure que estos no tocaran otros worksheets.

Arreglé tambien unas pequeñas cosas en los regex de los comandos.

Lo otro, algo que creo que es facil de arreglar pero no se si es necesario es que en todo el proceso de escoger ganadores y la asignacion de karma solo se guarda el nombre del usuario (_mention_name_ en Slack, que es variable), por lo que una persona puede cambiarse el nombre y tener mas probabilidades de ganar registrandose dos veces. Creo que lo mejor seria guardando solo el id de las personas, pero es algo minimo igual, no es que funcione mal.