### PR TITLE
feat(): Normalize karma the first day of every month

### DIFF
--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -192,6 +192,9 @@ module Lita
         scheduler.cron(ENV['PERSIST_CRON']) do
           persist_winning_lunchers
         end
+        scheduler.cron(ENV['RESET_KARMA_CRON']) do
+          @assigner.reset_karma
+        end
       end
 
       Lita.register_handler(self)

--- a/lib/lita/services/lunch_assigner.rb
+++ b/lib/lita/services/lunch_assigner.rb
@@ -110,6 +110,17 @@ module Lita
         pick_winners(ENV['MAX_LUNCHERS'].to_i)
         redis.set("already_assigned", true)
       end
+
+      def reset_karma
+        min_luncher_karma = lunchers_list.map { |luncher| get_karma(luncher) }.min
+        max_karma_after_reset = -10
+        return if min_luncher_karma >= max_karma_after_reset
+        lunchers_list.each do |luncher|
+          karma = get_karma(luncher)
+          new_karma = max_karma_after_reset * karma / min_luncher_karma
+          set_karma(luncher, new_karma)
+        end
+      end
     end
   end
 end

--- a/spec/lita/services/lunch_assigner_spec.rb
+++ b/spec/lita/services/lunch_assigner_spec.rb
@@ -72,8 +72,58 @@ describe Lita::Services::LunchAssigner, lita: true do
     subject.set_karma("john", 2)
     subject.add_to_current_lunchers("john")
     subject.set_karma("john", 6)
-    subject.pick_winners(3)
+    subject.pick_winners(2)
     expect(subject.winning_lunchers_list).to include('peter')
     expect(subject.winning_lunchers_list.count).to eq(2)
+  end
+
+  describe '#reset_karma' do
+    context 'with min_karma less than -10' do
+      before do
+        subject.add_to_lunchers('jaime')
+        subject.set_karma('jaime', -5)
+        subject.add_to_lunchers('saratscheff')
+        subject.set_karma('saratscheff', -20)
+        subject.add_to_lunchers('oscar')
+        subject.set_karma('oscar', -10)
+        subject.add_to_lunchers('giovanni')
+        subject.set_karma('giovanni', -100)
+        subject.add_to_lunchers('agustin')
+        subject.set_karma('agustin', -40)
+      end
+
+      it 'resets karma correctly' do
+        subject.reset_karma
+        expect(subject.get_karma('jaime')).to eq(-1)
+        expect(subject.get_karma('saratscheff')).to eq(-2)
+        expect(subject.get_karma('oscar')).to eq(-1)
+        expect(subject.get_karma('giovanni')).to eq(-10)
+        expect(subject.get_karma('agustin')).to eq(-4)
+      end
+    end
+
+    context 'with min_karma greater than -10' do
+      before do
+        subject.add_to_lunchers('jaime')
+        subject.set_karma('jaime', -1)
+        subject.add_to_lunchers('saratscheff')
+        subject.set_karma('saratscheff', -2)
+        subject.add_to_lunchers('oscar')
+        subject.set_karma('oscar', -2)
+        subject.add_to_lunchers('giovanni')
+        subject.set_karma('giovanni', -4)
+        subject.add_to_lunchers('agustin')
+        subject.set_karma('agustin', -6)
+      end
+
+      it 'resets karma correctly' do
+        subject.reset_karma
+        expect(subject.get_karma('jaime')).to eq(-1)
+        expect(subject.get_karma('saratscheff')).to eq(-2)
+        expect(subject.get_karma('oscar')).to eq(-2)
+        expect(subject.get_karma('giovanni')).to eq(-4)
+        expect(subject.get_karma('agustin')).to eq(-6)
+      end
+    end
   end
 end


### PR DESCRIPTION
# Cambios
- Se agrega un método para resetear el karma cada mes, básicamente, normaliza todos los karmas para que queden entre 0 y -10 (así no se pierde por completo la historia, pero pierde peso).

OJO: Se tiene que setear la variable de entorno `RESET_KARMA_CRON`, para que se corra el primer día de cada mes, debería ser `0 0 1 * *`.
OJO2: Estas semanas en que no está la Vicky, pondría que se corra cada semana, para probar si funciona (`0 0 * * 1`)