### PR TITLE
fix(weighted.picker): Remove positive? due to ruby version

### DIFF
--- a/lib/lita/services/weighted_picker.rb
+++ b/lib/lita/services/weighted_picker.rb
@@ -2,7 +2,7 @@ module Lita
   module Services
     class WeightedPicker
       def initialize(weighted_hash)
-        raise NonPositiveKarmaError unless weighted_hash.values.all?(&:positive?)
+        raise NonPositiveKarmaError unless weighted_hash.values.all? { |v| v > 0 }
         @weighted_hash = weighted_hash
         @total_elements = weighted_hash.count
       end


### PR DESCRIPTION
# Cambios
- Sacar `positive?` (es de la versión 2.3)