### PR TITLE
fix(handler): calculate karma before new user creation

### DIFF
--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -33,12 +33,12 @@ module Lita
       end
       route(/por\sfavor\sconsidera\sa\s([^\s]+)\s(para|en) (el|los) almuerzos?/,
         command: true, help: help_msg(:consider_user)) do |response|
+        karma_for_new_user = @karmanager.average_karma(@assigner.lunchers_list)
         mention_name = clean_mention_name(response.matches[0][0])
         success = @assigner.add_to_lunchers(mention_name)
         if success
           response.reply(t(:will_ask_daily, subject: mention_name))
           user = Lita::User.find_by_mention_name(mention_name)
-          karma_for_new_user = @karmanager.average_karma(@assigner.lunchers_list)
           @karmanager.set_karma(user.id, karma_for_new_user)
           response.reply("Le asigne #{karma_for_new_user} a #{user.mention_name} con id #{user.id}")
         else


### PR DESCRIPTION
Cuanto entra una persona nueva, el karma que tendrá será 0. Luego, el método para calcular el karma promedio considerará a esta persona bajando el karma antes de la asignación. Es por lo anterior que en este PR se calcula el karma promedio antes de agregar el nuevo usuario a la lista de forma que entre con el karma promedio de los usuarios.