### PR TITLE
feat(api): transfer karma

### DIFF
--- a/lib/lita/handlers/api/api_controller.rb
+++ b/lib/lita/handlers/api/api_controller.rb
@@ -17,7 +17,7 @@ module Lita
         def authorized?(request)
           user_id = request.params[:user_id]
           user = Lita::User.find_by_id(user_id)
-          user.present?
+          !user.nil?
         end
 
         Lita.register_handler(self)

--- a/lib/lita/handlers/api/karma.rb
+++ b/lib/lita/handlers/api/karma.rb
@@ -15,6 +15,7 @@ module Lita
         end
 
         http.get '/karma', :karma
+        http.post '/karma/transfer', :transfer
 
         def karma(request, response)
           return respond_not_authorized(response) unless authorized?(request)
@@ -22,6 +23,21 @@ module Lita
           if user
             user_karma = @karmanager.get_karma(user.id)
             respond(response, karma: user_karma)
+          end
+        end
+
+        def transfer(request, response)
+          return respond_not_authorized(response) unless authorized?(request)
+          body = JSON.parse(request.body.read)
+          user = Lita::User.find_by_id(request.params[:user_id])
+          receiver = Lita::User.find_by_id(body['receiver_id'])
+          karma_amount = body['karma_amount']
+          if user && receiver && karma_amount
+            @karmanager.transfer_karma(user.id, receiver.id, karma_amount)
+            respond(response, success: true)
+          else
+            response.status = 404
+            respond(response, status: 404, message: 'Error in parameters')
           end
         end
 

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -156,7 +156,7 @@ module Lita
         giver = response.user
         mention_name = clean_mention_name(response.matches[0][0])
         destinatary = Lita::User.find_by_mention_name(mention_name)
-        @karmanager.transfer_karma(giver.id, destinatary.id)
+        @karmanager.transfer_karma(giver.id, destinatary.id, 1)
         response.reply(
           "@#{giver.mention_name}, le has dado uno de tus puntos de " +
           "karma a @#{destinatary.mention_name}."

--- a/lib/lita/services/karmanager.rb
+++ b/lib/lita/services/karmanager.rb
@@ -32,9 +32,9 @@ module Lita
         @redis.decrby("#{user_id}:karma", amount)
       end
 
-      def transfer_karma(giver_id, receiver_id)
-        decrease_karma(giver_id)
-        increase_karma(receiver_id)
+      def transfer_karma(giver_id, receiver_id, amount)
+        decrease_karma_by(giver_id, amount)
+        increase_karma_by(receiver_id, amount)
       end
 
       def convert_to_new_karma(list, base)

--- a/spec/lita/handlers/api/karma_spec.rb
+++ b/spec/lita/handlers/api/karma_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe Lita::Handlers::Api::Karma, lita_handler: true do
+  let(:redis) { Lita::Handlers::LunchReminder.new(robot).redis }
+  let(:karmanager) do
+    Lita::Services::Karmanager.new(redis)
+  end
+  let(:assigner) { Lita::Services::LunchAssigner.new(redis, karmanager) }
+  let(:juan) { Lita::User.create(127, mention_name: 'juan') }
+  let(:pedro) { Lita::User.create(137, mention_name: 'pedro') }
+
+  it { is_expected.to route_http(:get, 'karma') }
+
+  before do
+    assigner.add_to_lunchers('juan')
+    assigner.add_to_lunchers('pedro')
+    karmanager.set_karma(juan.id, 10)
+    karmanager.set_karma(pedro.id, 20)
+  end
+
+  describe '#karma' do
+    context 'not authorized' do
+      it 'responds with not autorized' do
+        response = JSON.parse(http.get('karma').body)
+        expect(response['status']).to eq(401)
+        expect(response['message']).to eq('Not authorized')
+      end
+    end
+
+    context 'authorized' do
+      before do
+        allow_any_instance_of(Rack::Request).to receive(:params).and_return(user_id: juan.id)
+        @response = JSON.parse(http.get('karma').body)
+      end
+
+      it 'writes responds with user karma' do
+        expect(@response['karma']).to eq(10)
+      end
+    end
+  end
+
+  describe '#transfer' do
+    context 'not authorized' do
+      it 'responds with not autorized' do
+        response = JSON.parse(http.post('karma/transfer').body)
+        expect(response['status']).to eq(401)
+        expect(response['message']).to eq('Not authorized')
+      end
+    end
+
+    context 'authorized' do
+      before do
+        allow_any_instance_of(Rack::Request).to receive(:params).and_return(user_id: juan.id)
+        @juan_karma = karmanager.get_karma(juan.id)
+        @pedro_karma = karmanager.get_karma(pedro.id)
+        @response = JSON.parse(http.post do |req|
+          req.url 'karma/transfer'
+          req.body = "{\"receiver_id\": \"#{pedro.id}\", \"karma_amount\": 5 }"
+        end.body)
+      end
+
+      it 'responds with success' do
+        expect(@response['success']).to eq(true)
+      end
+
+      it 'transfers the karma' do
+        expect(karmanager.get_karma(juan.id)).to eq(@juan_karma - 5)
+        expect(karmanager.get_karma(pedro.id)).to eq(@pedro_karma + 5)
+      end
+    end
+  end
+end

--- a/spec/lita/handlers/api/lunch_spec.rb
+++ b/spec/lita/handlers/api/lunch_spec.rb
@@ -1,0 +1,104 @@
+require 'spec_helper'
+
+describe Lita::Handlers::Api::Lunch, lita_handler: true do
+  let(:redis) { Lita::Handlers::LunchReminder.new(robot).redis }
+  let(:karmanager) do
+    Lita::Services::Karmanager.new(redis)
+  end
+  let(:assigner) { Lita::Services::LunchAssigner.new(redis, karmanager) }
+  let(:juan) { Lita::User.create(127, mention_name: 'juan') }
+  let(:pedro) { Lita::User.create(137, mention_name: 'pedro') }
+  let(:oscar) { Lita::User.create(157, mention_name: 'oscar') }
+
+  it { is_expected.to route_http(:get, 'winning_lunchers') }
+  it { is_expected.to route_http(:get, 'current_lunchers') }
+  it { is_expected.to route_http(:post, 'current_lunchers') }
+
+  before do
+    ENV['MAX_LUNCHERS'] = '20'
+    assigner.add_to_lunchers('juan')
+    assigner.add_to_lunchers('pedro')
+    assigner.add_to_lunchers('oscar')
+    karmanager.set_karma(juan.id, 10)
+    karmanager.set_karma(pedro.id, 20)
+    assigner.add_to_current_lunchers(juan.mention_name)
+    assigner.add_to_current_lunchers(pedro.mention_name)
+    assigner.add_to_winning_lunchers(pedro.mention_name)
+  end
+
+  describe '#winning_lunchers' do
+    context 'not authorized' do
+      it 'responds with not autorized' do
+        response = JSON.parse(http.get('winning_lunchers').body)
+        expect(response['status']).to eq(401)
+        expect(response['message']).to eq('Not authorized')
+      end
+    end
+
+    context 'authorized' do
+      before do
+        allow_any_instance_of(Rack::Request).to receive(:params).and_return(user_id: juan.id)
+        @response = JSON.parse(http.get('winning_lunchers').body)
+      end
+
+      it 'includes the winning lunchers' do
+        expect(@response['winning_lunchers']).to include('pedro')
+      end
+
+      it 'doesnt include non winning lunchers' do
+        expect(@response['winning_lunchers']).not_to include('juan')
+      end
+    end
+  end
+
+  describe '#current_lunchers' do
+    context 'not authorized' do
+      it 'responds with not autorized' do
+        response = JSON.parse(http.get('winning_lunchers').body)
+        expect(response['status']).to eq(401)
+        expect(response['message']).to eq('Not authorized')
+      end
+    end
+
+    context 'authorized' do
+      before do
+        allow_any_instance_of(Rack::Request).to receive(:params).and_return(user_id: juan.id)
+        @response = JSON.parse(http.get('current_lunchers').body)
+      end
+
+      it 'includes the current lunchers' do
+        expect(@response['current_lunchers']).to include('juan', 'pedro')
+      end
+
+      it 'not includes other lunchers' do
+        expect(@response['current_lunchers']).not_to include('oscar')
+      end
+    end
+  end
+
+  describe '#opt_in' do
+    context 'not authorized' do
+      it 'responds with not autorized' do
+        response = JSON.parse(http.post('current_lunchers').body)
+        expect(response['status']).to eq(401)
+        expect(response['message']).to eq('Not authorized')
+      end
+    end
+
+    context 'authorized' do
+      before do
+        allow_any_instance_of(Rack::Request).to receive(:params).and_return(user_id: oscar.id)
+        @response = JSON.parse(http.post('current_lunchers').body)
+      end
+
+      it 'responds with success' do
+        expect(@response['success']).to be(true)
+      end
+
+      it 'adds user to current lunchers' do
+        current_lunchers = assigner.current_lunchers_list
+        expect(current_lunchers).to include(oscar.mention_name)
+      end
+    end
+  end
+end

--- a/spec/lita/services/karmanager_spec.rb
+++ b/spec/lita/services/karmanager_spec.rb
@@ -18,7 +18,7 @@ describe Lita::Services::Karmanager, lita: true do
   it "transfers karma" do
     subject.set_karma("agustin", 1000)
     subject.set_karma("peter", 1000)
-    subject.transfer_karma("agustin", "peter")
+    subject.transfer_karma("agustin", "peter", 1)
     expect(subject.get_karma("agustin")).to eq(999)
   end
 

--- a/spec/lita/services/lunch_assigner_spec.rb
+++ b/spec/lita/services/lunch_assigner_spec.rb
@@ -76,9 +76,9 @@ describe Lita::Services::LunchAssigner, lita: true do
     karmanager.set_karma(juan.id, 2)
     subject.pick_winners(3)
     expect(subject.winning_lunchers_list).to include('pedro')
-    expect(subject.winning_lunchers_list.count).to eq(2)
+    expect(subject.winning_lunchers_list.count).to eq(3)
   end
-  
+
   it "knows the day of the week" do
     fake_today = Date.parse('2018-01-01')
     allow(Date).to receive(:today).and_return(fake_today)


### PR DESCRIPTION
- Se agrega endpoint
```
POST /karma/transfer
{
   "receiver_id": "id_usuario_slack"
}
```

- Se agrega `amount` a método `#transfer_karma`
- Se agregan tests para todos los endpoint de la API
- Se arregla un test que esperaba un valor incorrecto
