### PR TITLE
fix(api): change parameters received by transfer endpoint

### DIFF
--- a/lib/lita/handlers/api/karma.rb
+++ b/lib/lita/handlers/api/karma.rb
@@ -30,8 +30,8 @@ module Lita
           return respond_not_authorized(response) unless authorized?(request)
           body = JSON.parse(request.body.read)
           user = Lita::User.find_by_id(request.params[:user_id])
-          receiver = Lita::User.find_by_id(body['receiver_id'])
-          karma_amount = body['karma_amount']
+          receiver = Lita::User.find_by_mention_name(body['receiver'])
+          karma_amount = body['amount']
           if user && receiver && karma_amount
             @karmanager.transfer_karma(user.id, receiver.id, karma_amount)
             respond(response, success: true)

--- a/spec/lita/handlers/api/karma_spec.rb
+++ b/spec/lita/handlers/api/karma_spec.rb
@@ -55,7 +55,7 @@ describe Lita::Handlers::Api::Karma, lita_handler: true do
         @pedro_karma = karmanager.get_karma(pedro.id)
         @response = JSON.parse(http.post do |req|
           req.url 'karma/transfer'
-          req.body = "{\"receiver_id\": \"#{pedro.id}\", \"karma_amount\": 5 }"
+          req.body = "{\"receiver\": \"#{pedro.mention_name}\", \"amount\": 5 }"
         end.body)
       end
 


### PR DESCRIPTION
Desde la app no manejamos el `id` del usuario, solo el `mention_name`. Este PR considera eso.