### PR TITLE
Transfer lunch endpoint

### DIFF
--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -184,9 +184,9 @@ module Lita
       end
 
       def quiet_time?
-        ((1..5).cover? DateTime.current.wday) &&
-          (DateTime.now.hour >= ENV['QUIET_START_HOUR'].to_i) &&
-          (DateTime.now.hour <= ENV['QUIET_END_HOUR'].to_i)
+        ((1..5).cover? Time.now.wday) &&
+          (Time.now.hour >= ENV['QUIET_START_HOUR'].to_i) &&
+          (Time.now.hour <= ENV['QUIET_END_HOUR'].to_i)
       end
 
       def clean_mention_name(mention_name)

--- a/spec/lita/handlers/api/lunch_spec.rb
+++ b/spec/lita/handlers/api/lunch_spec.rb
@@ -101,4 +101,79 @@ describe Lita::Handlers::Api::Lunch, lita_handler: true do
       end
     end
   end
+
+  describe '#transfer' do
+    context 'not authorized' do
+      it 'responds with not autorized' do
+        response = JSON.parse(http.post('current_lunchers').body)
+        expect(response['status']).to eq(401)
+        expect(response['message']).to eq('Not authorized')
+      end
+    end
+
+    context 'authorized' do
+      context 'receiver doesn\'t exist' do
+        before do
+          allow_any_instance_of(Rack::Request).to receive(:params).and_return(user_id: pedro.id)
+          @response = JSON.parse(http.post do |req|
+            req.url 'lunches/transfer'
+            req.body = "{\"receiver\": \"batman\"}"
+          end.body)
+        end
+
+        it { expect(@response['status']).to eq(404) }
+        it { expect(@response['message']).to eq('Error in parameters') }
+
+        it 'should not remove sender from winning lunchers' do
+          winning_lunchers = assigner.winning_lunchers_list
+          expect(winning_lunchers).to include(pedro.mention_name)
+        end
+      end
+
+      context 'sender did not win lunch' do
+        before do
+          allow_any_instance_of(Rack::Request).to receive(:params).and_return(user_id: juan.id)
+          @response = JSON.parse(http.post do |req|
+            req.url 'lunches/transfer'
+            req.body = "{\"receiver\": \"#{pedro.mention_name}\"}"
+          end.body)
+        end
+
+        it { expect(@response['status']).to eq(404) }
+        it { expect(@response['message']).to eq('User not in winning lunchers') }
+
+        it 'should not remove sender from winning lunchers' do
+          winning_lunchers = assigner.winning_lunchers_list
+          expect(winning_lunchers).to include(pedro.mention_name)
+        end
+
+        it 'should not add receiver to winning lunchers' do
+          winning_lunchers = assigner.winning_lunchers_list
+          expect(winning_lunchers).not_to include(juan.mention_name)
+        end
+      end
+
+      context 'sender won lunch' do
+        before do
+          allow_any_instance_of(Rack::Request).to receive(:params).and_return(user_id: pedro.id)
+          @response = JSON.parse(http.post do |req|
+            req.url 'lunches/transfer'
+            req.body = "{\"receiver\": \"#{juan.mention_name}\"}"
+          end.body)
+        end
+
+        it { expect(@response['success']).to be(true) }
+
+        it 'should remove sender from winning lunchers' do
+          winning_lunchers = assigner.winning_lunchers_list
+          expect(winning_lunchers).not_to include(pedro.mention_name)
+        end
+
+        it 'should add receiver to winning lunchers' do
+          winning_lunchers = assigner.winning_lunchers_list
+          expect(winning_lunchers).to include(juan.mention_name)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Endpoint para transferir almuerzo
```
POST /lunches/transfer
{
   "receiver": "mention name de usuario"
}
```
Los headers son los mismos de siempre.

- Se arregla un error al usar `DateTime.current`, que solo existe en Rails