### PR TITLE
feat(Market): Market integration with slack

### DIFF
--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -42,8 +42,8 @@ module Lita
           karma_for_new_user = @karmanager.average_karma(@assigner.lunchers_list)
           @karmanager.set_karma(user.id, karma_for_new_user)
           response.reply("Le asigne #{karma_for_new_user} a #{user.mention_name} con id #{user.id}")
-          broadcast_to_audit_channel("Se empezó a considerar a #{user.mention_name}. " +
-            "Nuevo karma:  #{karma_for_new_user}")
+          broadcast_to_channel("Se empezó a considerar a #{user.mention_name}. " +
+            "Nuevo karma:  #{karma_for_new_user}", '#karma-audit')
         else
           response.reply(t(:already_considered, subject: mention_name))
         end
@@ -62,7 +62,7 @@ module Lita
         mention_name = clean_mention_name(response.matches[0][0])
         @assigner.remove_from_lunchers(mention_name)
         response.reply(t(:thanks_for_answering))
-        broadcast_to_audit_channel("Se dejó de considerar a #{mention_name}")
+        broadcast_to_channel("Se dejó de considerar a #{mention_name}", '#karma-audit')
       end
       route(/^s[íi]$|^hoy almuerzo aqu[íi]$/i,
         command: true, help: help_msg(:confirm_yes)) do |response|
@@ -165,8 +165,8 @@ module Lita
           "@#{giver.mention_name}, le has dado uno de tus puntos de " +
           "karma a @#{destinatary.mention_name}."
         )
-        broadcast_to_audit_channel("@#{giver.mention_name}, le ha dado un punto de " +
-          "karma a @#{destinatary.mention_name}.")
+        broadcast_to_channel("@#{giver.mention_name}, le ha dado un punto de " +
+          "karma a @#{destinatary.mention_name}.", '#karma-audit')
       end
 
       route(/c[eé]dele mi puesto a ([^\s]+)/i, command: true) do |response|
@@ -199,7 +199,7 @@ module Lita
         response.reply(
           "@#{user.mention_name}, tengo tu almuerzo en venta!"
         )
-        broadcast_to_audit_channel("@#{user.mention_name}, tengo tu almuerzo en venta!")
+        broadcast_to_channel("@#{user.mention_name}, tengo tu almuerzo en venta!", '#cooking')
       end
 
       route(/compr(o|ame|a)? (un )?almuerzo/i, command: true) do |response|
@@ -209,13 +209,13 @@ module Lita
           next
         end
         response.reply(
-          "@#{user.mention_name}, tengo tu almuerzo en venta!"
+          "@#{user.mention_name}, ya te consegui almuerzo!"
         )
-        broadcast_to_audit_channel("@#{user.mention_name}, ya te consegui almuerzo!")
+        broadcast_to_channel("@#{user.mention_name}, ya te consegui almuerzo!", '#cooking')
       end
 
-      def broadcast_to_audit_channel(message)
-        target = Source.new(room: '#karma-audit')
+      def broadcast_to_channel(message, channel)
+        target = Source.new(room: channel)
         robot.send_message(target, message)
       end
 

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -196,7 +196,7 @@ module Lita
           response.reply('No puedes vender algo que no tienes!')
           next
         end
-        response.reply(
+        response.reply_privately(
           "@#{user.mention_name}, tengo tu almuerzo en venta!"
         )
         broadcast_to_channel("@#{user.mention_name}, tengo tu almuerzo en venta!", '#cooking')
@@ -204,14 +204,15 @@ module Lita
 
       route(/c(o|ó)mpr(o|ame|a)? (un )?almuerzo/i, command: true) do |response|
         user = response.user
-        unless @market.add_market_order(user.id)
+        seller_user = @market.add_market_order(user.id)
+        unless seller_user
           response.reply('no te puedo comprar almuerzo...')
           next
         end
-        response.reply(
-          "@#{user.mention_name}, ya te consegui almuerzo!"
-        )
-        broadcast_to_channel("@#{user.mention_name}, ya te consegui almuerzo!", '#cooking')
+        response.reply_privately("@#{user.mention_name}, ya te consegui almuerzo!")
+        broadcast_to_channel(
+          "@#{user.mention_name} le compró almuerzo a @#{seller_user.mention_name}",
+          '#cooking')
       end
 
       def broadcast_to_channel(message, channel)

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -182,8 +182,8 @@ module Lita
       route(/.*/i, command: false) do |response|
         if quiet_time? && Lita::Room.find_by_name('lita-test').id == response.room.id
           user = Lita::User.find_by_mention_name('agustin')
-          message = 'Estoy empezando a sugerir que evitemos hablar en #coffeebar entre las 10 y las ' \
-          '12 del día para que la gente en la oficina pueda concentrarse. Las interrupciones' \
+          message = 'Estoy empezando a sugerir que evitemos hablar en #coffeebar entre las 10 y' \
+          'las 12 del día para que la gente en la oficina pueda concentrarse. Las interrupciones' \
           ' hacen muy dificil trabajar! mira: http://www.paulgraham.com/makersschedule.html'
           robot.send_message(Source.new(user: user), message) if user
         end
@@ -213,7 +213,8 @@ module Lita
         response.reply_privately("@#{user.mention_name}, ya te consegui almuerzo!")
         broadcast_to_channel(
           "@#{user.mention_name} le compró almuerzo a @#{seller_user.mention_name}",
-          '#cooking')
+          '#cooking'
+        )
       end
 
       def broadcast_to_channel(message, channel)

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -87,12 +87,12 @@ module Lita
             @assigner.add_to_winning_lunchers("invitado_de_#{response.user.mention_name}")
           response.reply(t(:friend_added, subject: response.user.mention_name))
         else
-          response.reply("tu amigo no cabe wn")
+          response.reply('tu amigo no cabe wn')
         end
       end
 
       route(/tengo una invitada/i, command: true) do |response|
-        response.reply("es rica?")
+        response.reply('es rica?')
       end
 
       route(/qui[ée]nes almuerzan hoy/i, help: help_msg(:show_today_lunchers)) do |response|
@@ -141,7 +141,7 @@ module Lita
       route(/assignnow/i, command: true) do |response|
         @assigner.do_the_assignment
         announce_winners
-        response.reply("did it boss")
+        response.reply('did it boss')
       end
 
       route(/cu[áa]nto karma tengo\??/i, command: true) do |response|
@@ -171,7 +171,7 @@ module Lita
 
       route(/c[eé]dele mi puesto a ([^\s]+)/i, command: true) do |response|
         unless @assigner.remove_from_winning_lunchers(response.user.mention_name)
-          response.reply("no puedes ceder algo que no tienes, amiguito")
+          response.reply('no puedes ceder algo que no tienes, amiguito')
           next
         end
         enters = clean_mention_name(response.matches[0][0])
@@ -180,11 +180,11 @@ module Lita
       end
 
       route(/.*/i, command: false) do |response|
-        if quiet_time? && Lita::Room.find_by_name("lita-test").id == response.room.id
-          user = Lita::User.find_by_mention_name("agustin")
-          message = "Estoy empezando a sugerir que evitemos hablar en #coffeebar entre las 10 y las " \
-          "12 del día para que la gente en la oficina pueda concentrarse. Las interrupciones" \
-          " hacen muy dificil trabajar! mira: http://www.paulgraham.com/makersschedule.html"
+        if quiet_time? && Lita::Room.find_by_name('lita-test').id == response.room.id
+          user = Lita::User.find_by_mention_name('agustin')
+          message = 'Estoy empezando a sugerir que evitemos hablar en #coffeebar entre las 10 y las ' \
+          '12 del día para que la gente en la oficina pueda concentrarse. Las interrupciones' \
+          ' hacen muy dificil trabajar! mira: http://www.paulgraham.com/makersschedule.html'
           robot.send_message(Source.new(user: user), message) if user
         end
       end

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -202,6 +202,18 @@ module Lita
         broadcast_to_audit_channel("@#{user.mention_name}, tengo tu almuerzo en venta!")
       end
 
+      route(/compr(o|ame|a)? (un )?almuerzo/i, command: true) do |response|
+        user = response.user
+        unless @market.add_market_order(user.id)
+          response.reply('no te puedo comprar almuerzo...')
+          next
+        end
+        response.reply(
+          "@#{user.mention_name}, tengo tu almuerzo en venta!"
+        )
+        broadcast_to_audit_channel("@#{user.mention_name}, ya te consegui almuerzo!")
+      end
+
       def broadcast_to_audit_channel(message)
         target = Source.new(room: '#karma-audit')
         robot.send_message(target, message)

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -202,7 +202,7 @@ module Lita
         broadcast_to_channel("@#{user.mention_name}, tengo tu almuerzo en venta!", '#cooking')
       end
 
-      route(/compr(o|ame|a)? (un )?almuerzo/i, command: true) do |response|
+      route(/c(o|ó)mpr(o|ame|a)? (un )?almuerzo/i, command: true) do |response|
         user = response.user
         unless @market.add_market_order(user.id)
           response.reply('no te puedo comprar almuerzo...')

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -204,11 +204,12 @@ module Lita
 
       route(/c(o|ó)mpr(o|ame|a)? (un )?almuerzo/i, command: true) do |response|
         user = response.user
-        seller_user = @market.add_market_order(user.id)
-        unless seller_user
+        order = @market.add_market_order(user.id)
+        unless order
           response.reply('no te puedo comprar almuerzo...')
           next
         end
+        seller_user = Lita::User.find_by_id(order['user_id'])
         response.reply_privately("@#{user.mention_name}, ya te consegui almuerzo!")
         broadcast_to_channel(
           "@#{user.mention_name} le compró almuerzo a @#{seller_user.mention_name}",

--- a/lib/lita/services/market_manager.rb
+++ b/lib/lita/services/market_manager.rb
@@ -36,6 +36,7 @@ module Lita
         lunch_buyer = Lita::User.find_by_id(lunch_buyer_id)
         @karmanager.transfer_karma(lunch_buyer.id, lunch_seller.id, 1)
         @lunch_assigner.transfer_lunch(lunch_seller.mention_name, lunch_buyer.mention_name)
+        lunch_seller
       end
 
       def remove_order

--- a/lib/lita/services/market_manager.rb
+++ b/lib/lita/services/market_manager.rb
@@ -36,7 +36,7 @@ module Lita
         lunch_buyer = Lita::User.find_by_id(lunch_buyer_id)
         @karmanager.transfer_karma(lunch_buyer.id, lunch_seller.id, 1)
         @lunch_assigner.transfer_lunch(lunch_seller.mention_name, lunch_buyer.mention_name)
-        lunch_seller
+        order
       end
 
       def remove_order

--- a/spec/lita/handlers/lunch_reminder_spec.rb
+++ b/spec/lita/handlers/lunch_reminder_spec.rb
@@ -1,53 +1,53 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe Lita::Handlers::LunchReminder, lita_handler: true do
-  it "responds to invite announcement" do
-    usr = Lita::User.create(123, name: "carlos")
-    send_message("@lita tengo un invitado", as: usr)
-    expect(replies.last).to eq("Perfecto @carlos, anoté a tu invitado como invitado_de_carlos.")
+  it 'responds to invite announcement' do
+    usr = Lita::User.create(123, name: 'carlos')
+    send_message('@lita tengo un invitado', as: usr)
+    expect(replies.last).to eq('Perfecto @carlos, anoté a tu invitado como invitado_de_carlos.')
   end
-  it "responds to user" do
-    usr = Lita::User.create(124, name: "armando")
-    send_message("@lita tengo un invitado", as: usr)
-    expect(replies.last).to eq("Perfecto @armando, anoté a tu invitado como invitado_de_armando.")
+  it 'responds to user' do
+    usr = Lita::User.create(124, name: 'armando')
+    send_message('@lita tengo un invitado', as: usr)
+    expect(replies.last).to eq('Perfecto @armando, anoté a tu invitado como invitado_de_armando.')
   end
-  it "responds to user" do
-    usr = Lita::User.create(124, name: "armando")
-    send_message("@lita tengo un invitado", as: usr)
-    send_message("quienes almuerzan hoy?", as: usr)
-    expect(replies.last).to match("no lo se")
+  it 'responds to user' do
+    usr = Lita::User.create(124, name: 'armando')
+    send_message('@lita tengo un invitado', as: usr)
+    send_message('quienes almuerzan hoy?', as: usr)
+    expect(replies.last).to match('no lo se')
   end
-  it "responds that invitee does not fit" do
+  it 'responds that invitee does not fit' do
     ['armando', 'luis', 'peter'].each do |name|
       usr = Lita::User.create(124, name: name)
-      send_message("@lita tengo un invitado", as: usr)
+      send_message('@lita tengo un invitado', as: usr)
     end
-    expect(replies.last).to match("no cabe")
+    expect(replies.last).to match('no cabe')
   end
-  it "does not allow a user to give his place before he has it" do
-    usr = Lita::User.create(124, name: "armando")
-    send_message("@lita hoy almuerzo aquí", as: usr)
-    send_message("@lita cédele mi puesto a patricio", as: usr)
-    expect(replies.last).to match("algo que no tienes")
+  it 'does not allow a user to give his place before he has it' do
+    usr = Lita::User.create(124, name: 'armando')
+    send_message('@lita hoy almuerzo aquí', as: usr)
+    send_message('@lita cédele mi puesto a patricio', as: usr)
+    expect(replies.last).to match('algo que no tienes')
   end
-  it "answers with the user karma" do
-    usr = Lita::User.create(124, name: "armando")
-    send_message("@lita cuánto karma tengo?", as: usr)
-    expect(replies.last).to match("Tienes 0 puntos de karma, mi padawan")
+  it 'answerth the user karma' do
+    usr = Lita::User.create(124, name: 'armando')
+    send_message('@lita cuánto karma tengo?', as: usr)
+    expect(replies.last).to match('Tienes 0 puntos de karma, mi padawan')
   end
-  it "answers with the user karma" do
-    usr1 = Lita::User.create(124, name: "armando")
-    Lita::User.create(1292, mention_name: "fernando")
-    send_message("@lita cuánto karma tiene fernando?", as: usr1)
-    expect(replies.last).to match("@fernando tiene 0 puntos de karma.")
+  it 'answers with the user karma' do
+    usr1 = Lita::User.create(124, name: 'armando')
+    Lita::User.create(1292, mention_name: 'fernando')
+    send_message('@lita cuánto karma tiene fernando?', as: usr1)
+    expect(replies.last).to match('@fernando tiene 0 puntos de karma.')
   end
-  it "transfers karma" do
-    armando = Lita::User.create(124, mention_name: "armando")
-    jilberto = Lita::User.create(125, mention_name: "jilberto")
-    send_message("@lita transfierele karma a armando", as: jilberto)
-    send_message("@lita cuánto karma tengo?", as: jilberto)
-    expect(replies.last).to match("Tienes -1 puntos de karma, mi padawan")
-    send_message("@lita cuánto karma tengo?", as: armando)
-    expect(replies.last).to match("Tienes 1 puntos de karma, mi padawan")
+  it 'transfers karma' do
+    armando = Lita::User.create(124, mention_name: 'armando')
+    jilberto = Lita::User.create(125, mention_name: 'jilberto')
+    send_message('@lita transfierele karma a armando', as: jilberto)
+    send_message('@lita cuánto karma tengo?', as: jilberto)
+    expect(replies.last).to match('Tienes -1 puntos de karma, mi padawan')
+    send_message('@lita cuánto karma tengo?', as: armando)
+    expect(replies.last).to match('Tienes 1 puntos de karma, mi padawan')
   end
 end

--- a/spec/lita/handlers/lunch_reminder_spec.rb
+++ b/spec/lita/handlers/lunch_reminder_spec.rb
@@ -38,7 +38,7 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
     send_message('@lita cédele mi puesto a patricio', as: usr)
     expect(replies.last).to match('algo que no tienes')
   end
-  it 'answerth the user karma' do
+  it 'answers the user karma' do
     usr = Lita::User.create(124, name: 'armando')
     send_message('@lita cuánto karma tengo?', as: usr)
     expect(replies.last).to match('Tienes 0 puntos de karma, mi padawan')
@@ -67,7 +67,7 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
       it 'responds that limit order was placed' do
         armando = Lita::User.create(124, mention_name: 'armando')
         send_message('@lita vende mi almuerzo', as: armando)
-        expect(replies.last).to match('Tengo tu almuerzo en venta!')
+        expect(replies.last).to match('tengo tu almuerzo en venta!')
       end
     end
     context 'user without lunch' do
@@ -77,7 +77,7 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
       it 'responds with an error' do
         armando = Lita::User.create(124, mention_name: 'armando')
         send_message('@lita vende mi almuerzo', as: armando)
-        expect(replies.last).to match('No puedes vender algo que no tienes!')
+        expect(replies.last).to match('no puedes vender algo que no tienes!')
       end
     end
   end

--- a/spec/lita/handlers/lunch_reminder_spec.rb
+++ b/spec/lita/handlers/lunch_reminder_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 require 'dotenv/load'
 
 describe Lita::Handlers::LunchReminder, lita_handler: true do
-  let(:user) { double }
 
   before do
     ENV['MAX_LUNCHERS'] = '3'
@@ -86,14 +85,20 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
 
   describe 'place market order' do
     context 'user can place market order' do
+      let(:user) { double }
+      let(:lita_user) { Lita::User }
+      let!(:user2) { Lita::User.create(124, mention_name: 'armando') }
       before do
-        allow_any_instance_of(Lita::Services::MarketManager).to receive(:add_market_order).and_return(user)
+        allow_any_instance_of(Lita::Services::MarketManager).to \
+          receive(:add_market_order).and_return('user_id': 123)
+        allow(lita_user).to receive(:find_by_id).and_return(user)
+        allow(lita_user).to receive(:create).and_return(user2)
         allow(user).to receive(:mention_name).and_return('felipe.dominguez')
       end
       it 'responds that market order was placed' do
         armando = Lita::User.create(124, mention_name: 'armando')
         send_message('@lita compro almuerzo', as: armando)
-        expect(replies.last).to match('ya te consegui almuerzo!')
+        expect(replies.last).to match('@armando le compró almuerzo a @felipe.dominguez')
       end
     end
     context "user cant' place market order" do

--- a/spec/lita/handlers/lunch_reminder_spec.rb
+++ b/spec/lita/handlers/lunch_reminder_spec.rb
@@ -62,7 +62,7 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
   describe 'place limit order' do
     context 'user has lunch' do
       before do
-        allow_any_instance_of(Lita::Handlers::Api::Market).to receive(:place_limit_order).and_return(true)
+        allow_any_instance_of(Lita::Services::MarketManager).to receive(:add_limit_order).and_return(true)
       end
       it 'responds that limit order was placed' do
         armando = Lita::User.create(124, mention_name: 'armando')
@@ -72,12 +72,12 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
     end
     context 'user without lunch' do
       before do
-        allow_any_instance_of(Lita::Handlers::Api::Market).to receive(:place_limit_order).and_return(false)
+        allow_any_instance_of(Lita::Services::MarketManager).to receive(:add_limit_order).and_return(false)
       end
       it 'responds with an error' do
         armando = Lita::User.create(124, mention_name: 'armando')
         send_message('@lita vende mi almuerzo', as: armando)
-        expect(replies.last).to match('no puedes vender algo que no tienes!')
+        expect(replies.last).to match('No puedes vender algo que no tienes!')
       end
     end
   end

--- a/spec/lita/handlers/lunch_reminder_spec.rb
+++ b/spec/lita/handlers/lunch_reminder_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 require 'dotenv/load'
 
 describe Lita::Handlers::LunchReminder, lita_handler: true do
-
   before do
     ENV['MAX_LUNCHERS'] = '3'
     ENV['WAIT_RESPONSES_SECONDS'] = '0 0 * * *'
@@ -63,7 +62,8 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
   describe 'place limit order' do
     context 'user has lunch' do
       before do
-        allow_any_instance_of(Lita::Services::MarketManager).to receive(:add_limit_order).and_return(true)
+        allow_any_instance_of(Lita::Services::MarketManager).to\
+          receive(:add_limit_order).and_return(true)
       end
       it 'responds that limit order was placed' do
         armando = Lita::User.create(124, mention_name: 'armando')
@@ -73,7 +73,8 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
     end
     context 'user without lunch' do
       before do
-        allow_any_instance_of(Lita::Services::MarketManager).to receive(:add_limit_order).and_return(false)
+        allow_any_instance_of(Lita::Services::MarketManager).to\
+          receive(:add_limit_order).and_return(false)
       end
       it 'responds with an error' do
         armando = Lita::User.create(124, mention_name: 'armando')
@@ -85,7 +86,7 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
 
   describe 'place market order' do
     context 'user can place market order' do
-      let(:user) { double }
+      let(:user) { double(mention_name: 'felipe.dominguez') }
       let(:lita_user) { Lita::User }
       let!(:user2) { Lita::User.create(124, mention_name: 'armando') }
       before do
@@ -93,7 +94,6 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
           receive(:add_market_order).and_return('user_id': 123)
         allow(lita_user).to receive(:find_by_id).and_return(user)
         allow(lita_user).to receive(:create).and_return(user2)
-        allow(user).to receive(:mention_name).and_return('felipe.dominguez')
       end
       it 'responds that market order was placed' do
         armando = Lita::User.create(124, mention_name: 'armando')
@@ -103,7 +103,8 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
     end
     context "user cant' place market order" do
       before do
-        allow_any_instance_of(Lita::Services::MarketManager).to receive(:add_market_order).and_return(false)
+        allow_any_instance_of(Lita::Services::MarketManager).to\
+          receive(:add_market_order).and_return(false)
       end
       it 'responds with an error' do
         armando = Lita::User.create(124, mention_name: 'armando')

--- a/spec/lita/handlers/lunch_reminder_spec.rb
+++ b/spec/lita/handlers/lunch_reminder_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 require 'dotenv/load'
 
 describe Lita::Handlers::LunchReminder, lita_handler: true do
+  let(:user) { double }
+
   before do
     ENV['MAX_LUNCHERS'] = '3'
     ENV['WAIT_RESPONSES_SECONDS'] = '0 0 * * *'
@@ -85,7 +87,8 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
   describe 'place market order' do
     context 'user can place market order' do
       before do
-        allow_any_instance_of(Lita::Services::MarketManager).to receive(:add_market_order).and_return(true)
+        allow_any_instance_of(Lita::Services::MarketManager).to receive(:add_market_order).and_return(user)
+        allow(user).to receive(:mention_name).and_return('felipe.dominguez')
       end
       it 'responds that market order was placed' do
         armando = Lita::User.create(124, mention_name: 'armando')

--- a/spec/lita/handlers/lunch_reminder_spec.rb
+++ b/spec/lita/handlers/lunch_reminder_spec.rb
@@ -81,4 +81,27 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
       end
     end
   end
+
+  describe 'place market order' do
+    context 'user can place market order' do
+      before do
+        allow_any_instance_of(Lita::Services::MarketManager).to receive(:add_market_order).and_return(true)
+      end
+      it 'responds that market order was placed' do
+        armando = Lita::User.create(124, mention_name: 'armando')
+        send_message('@lita compro almuerzo', as: armando)
+        expect(replies.last).to match('ya te consegui almuerzo!')
+      end
+    end
+    context "user cant' place market order" do
+      before do
+        allow_any_instance_of(Lita::Services::MarketManager).to receive(:add_market_order).and_return(false)
+      end
+      it 'responds with an error' do
+        armando = Lita::User.create(124, mention_name: 'armando')
+        send_message('@lita compro almuerzo', as: armando)
+        expect(replies.last).to match('no te puedo comprar almuerzo...')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Ahora se puede usar el **Market de Ham** con **Slack**. Por ahora sólo se pueden dejar órdenes de venta publicadas _(no se pueden dejar órdenes de compra)_.

- Se creó la ruta para vender un almuerzo diciendo `@ham vende mi almuerzo`. 
- Se creó la ruta para comprar un almuerzo diciendo `@ham compro almuerzo`.

Si cada orden se ejecuta correctamente, se manda un mensaje por interno al usuario y además se publica en el grupo cooking.

---

Algunos cambios que tuve que hacer:
- El método `place_market_order` de Market Manager ahora retorna la orden con la que hizo match en caso de hacerlo.
- broadcast_to_audit_channel ahora quedó estructurado para poder transmitir a un canal pasado como parámetro.