### PR TITLE
feat(market): place bid orders without ask orders

### DIFF
--- a/lib/lita/handlers/api/market.rb
+++ b/lib/lita/handlers/api/market.rb
@@ -14,7 +14,6 @@ module Lita
 
         http.get 'market/limit_orders', :limit_orders
         http.post 'market/limit_orders', :place_limit_order
-        http.post 'market/market_orders', :place_market_order
 
         def limit_orders(request, response)
           return respond_not_authorized(response) unless authorized?(request)
@@ -32,22 +31,6 @@ module Lita
             else
               response.status = 403
               respond(response, status: 403, message: 'Can not place order')
-            end
-          else
-            response.status = 404
-            respond(response, status: 404, message: 'Error in parameters')
-          end
-        end
-
-        def place_market_order(request, response)
-          return respond_not_authorized(response) unless authorized?(request)
-          user = current_user(request)
-          if user
-            if !winning_list.include?(user.mention_name) && market_manager.add_market_order(user.id)
-              respond(response, success: true)
-            else
-              response.status = 403
-              respond(response, status: 403, message: 'Can not buy lunch')
             end
           else
             response.status = 404

--- a/lib/lita/handlers/api/market.rb
+++ b/lib/lita/handlers/api/market.rb
@@ -24,7 +24,7 @@ module Lita
         def place_limit_order(request, response)
           return respond_not_authorized(response) unless authorized?(request)
           user = current_user(request)
-          order = limit_order_for_user(user)
+          order = limit_order_for_user(user, 'ask')
           if user
             if winning_list.include?(user.mention_name) && market_manager.add_limit_order(order)
               respond(response, success: true, order: order)
@@ -42,11 +42,11 @@ module Lita
 
         private
 
-        def limit_order_for_user(user)
+        def limit_order_for_user(user, type)
           {
             id: SecureRandom.uuid,
             user_id: user.id,
-            type: 'limit',
+            type: type,
             created_at: Time.now
           }.to_json
         end

--- a/lib/lita/handlers/api/market.rb
+++ b/lib/lita/handlers/api/market.rb
@@ -29,7 +29,7 @@ module Lita
             executed_orders = market_manager.execute_transaction
             unless executed_orders
               response.status = 403
-              respond(response, status: 403, message: 'Can not place order')
+              respond(response, status: 403, message: 'Any transaction possible')
             end
             respond(response, success: true, orders: executed_orders.to_json)
           end

--- a/lib/lita/handlers/api/market.rb
+++ b/lib/lita/handlers/api/market.rb
@@ -38,10 +38,14 @@ module Lita
         def place_limit_order(request, response)
           return respond_not_authorized(response) unless authorized?(request)
           user = current_user(request)
-          order = limit_order_for_user(user, 'ask')
+          type = request.params['type']
           if user
-            if winning_list.include?(user.mention_name) && market_manager.add_limit_order(order)
-              respond(response, success: true, order: order)
+            new_order = limit_order_for_user(user, type)
+            has_lunch = winning_list.include?(user.mention_name)
+            if has_lunch && type == 'ask' && market_manager.add_limit_order(new_order)
+              respond(response, success: true, order: new_order)
+            elsif !has_lunch && type == 'bid' && market_manager.add_limit_order(new_order)
+              respond(response, success: true, order: new_order)
             else
               response.status = 403
               respond(response, status: 403, message: 'Can not place order')

--- a/lib/lita/handlers/api/market.rb
+++ b/lib/lita/handlers/api/market.rb
@@ -13,8 +13,8 @@ module Lita
         end
 
         http.get 'market/limit_orders', :limit_orders
-        http.get 'market/execute_transaction', :execute_transaction
         http.post 'market/limit_orders', :place_limit_order
+        http.post 'market/execute_transaction', :execute_transaction
 
         def limit_orders(request, response)
           return respond_not_authorized(response) unless authorized?(request)

--- a/lib/lita/handlers/api/market.rb
+++ b/lib/lita/handlers/api/market.rb
@@ -13,12 +13,26 @@ module Lita
         end
 
         http.get 'market/limit_orders', :limit_orders
+        http.get 'market/execute_transaction', :execute_transaction
         http.post 'market/limit_orders', :place_limit_order
 
         def limit_orders(request, response)
           return respond_not_authorized(response) unless authorized?(request)
           orders = market_manager.orders
           respond(response, limit_orders: orders)
+        end
+
+        def execute_transaction(request, response)
+          return respond_not_authorized(response) unless authorized?(request)
+          user = current_user(request)
+          if user
+            executed_orders = market_manager.execute_transaction
+            unless executed_orders
+              response.status = 403
+              respond(response, status: 403, message: 'Can not place order')
+            end
+            respond(response, success: true, orders: executed_orders.to_json)
+          end
         end
 
         def place_limit_order(request, response)

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -198,10 +198,10 @@ module Lita
           next
         end
         order = @market.add_limit_order(new_order)
-        transaction_users = execute_transaction
         return unless order
-        if transaction_users
-          notify_transaction(transaction_users[0], transaction_users[1])
+        transaction = execute_transaction
+        if transaction
+          notify_transaction(transaction[:buyer], transaction[:seller])
         else
           response.reply_privately(
             "@#{user.mention_name}, #{t(:selling_lunch)}"
@@ -219,10 +219,10 @@ module Lita
           next
         end
         order = @market.add_limit_order(new_order)
-        transaction_users = execute_transaction
         return unless order
-        if transaction_users
-          notify_transaction(transaction_users[0], transaction_users[1])
+        transaction = execute_transaction
+        if transaction
+          notify_transaction(transaction[:buyer], transaction[:seller])
         else
           response.reply_privately(
             "@#{user.mention_name}, #{t(:buying_lunch)}"
@@ -302,7 +302,13 @@ module Lita
         bid_order = executed_orders[:bid]
         seller_user = Lita::User.find_by_id(ask_order[:user_id])
         buyer_user = Lita::User.find_by_id(bid_order[:user_id])
-        [buyer_user, seller_user]
+        {
+          buyer: buyer_user,
+          seller: seller_user,
+          timestamp: Time.now,
+          bid_order: bid_order,
+          ask_order: ask_order
+        }
       end
 
       def notify_transaction(buyer_user, seller_user)

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -192,12 +192,14 @@ module Lita
       route(/vend[oe] (mi|\s)? ?almuerzo/i,
         command: true, help: help_msg(:sell_lunch)) do |response|
         user = response.user
-        order = create_order(user, 'ask')
+        new_order = create_order(user, 'ask')
         unless winning_list.include?(user.mention_name)
           response.reply("@#{user.mention_name} #{t(:cant_sell)}")
           next
         end
-        if @market.add_limit_order(order)
+        order = @market.add_limit_order(new_order)
+        executed_orders = execute_transaction
+        if order && !executed_orders
           response.reply_privately(
             "@#{user.mention_name}, #{t(:selling_lunch)}"
           )
@@ -213,14 +215,14 @@ module Lita
           response.reply(t(:cant_buy))
           next
         end
-        seller_user = Lita::User.find_by_id(order['user_id'])
-        response.reply_privately("@#{user.mention_name}, #{t(:bought_lunch)}")
-        broadcast_to_channel(
-          t(:transaction,
-            subject1: user.mention_name,
-            subject2: seller_user.mention_name),
-          '#cooking'
-        )
+        order = @market.add_limit_order(order)
+        executed_orders = execute_transaction
+        if order && !executed_orders
+          response.reply_privately(
+            "@#{user.mention_name}, #{t(:buying_lunch)}"
+          )
+          broadcast_to_channel("@#{user.mention_name}, #{t(:buying_lunch)}", '#cooking')
+        end
       end
 
       def broadcast_to_channel(message, channel)
@@ -285,6 +287,25 @@ module Lita
 
       def winning_list
         @winning_list ||= @assigner.winning_lunchers_list
+      end
+
+      def execute_transaction
+        executed_orders = @market.execute_transaction
+        return unless executed_orders
+        ask_order = executed_orders[:ask]
+        bid_order = executed_orders[:bid]
+        seller_user = Lita::User.find_by_id(ask_order[:user_id])
+        buyer_user = Lita::User.find_by_id(bid_order[:user_id])
+        seller_message = "@#{seller_user.mention_name}, #{t(:sold_lunch)}"
+        buyer_message = "@#{buyer_user.mention_name}, #{t(:bought_lunch)}"
+        robot.send_message(Source.new(user: seller_user), seller_message) if seller_user
+        robot.send_message(Source.new(user: buyer_user), buyer_message) if buyer_user
+        broadcast_to_channel(
+          t(:transaction,
+            subject1: buyer_user.mention_name,
+            subject2: seller_user.mention_name),
+          '#cooking'
+        )
       end
 
       Lita.register_handler(self)

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -258,7 +258,7 @@ module Lita
       end
 
       def announce_winners
-        notify(@assigner.winning_lunchers_list, "Yeah baby, almuerzas con nosotros!")
+        notify(@assigner.winning_lunchers_list, 'Yeah baby, almuerzas con nosotros!')
         notify(@assigner.loosing_lunchers_list, t(:current_lunchers_too_many))
       end
 
@@ -301,9 +301,7 @@ module Lita
         robot.send_message(Source.new(user: seller_user), seller_message) if seller_user
         robot.send_message(Source.new(user: buyer_user), buyer_message) if buyer_user
         broadcast_to_channel(
-          t(:transaction,
-            subject1: buyer_user.mention_name,
-            subject2: seller_user.mention_name),
+          t(:transaction, subject1: buyer_user.mention_name, subject2: seller_user.mention_name),
           '#cooking'
         )
       end

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -192,7 +192,7 @@ module Lita
       route(/vend[oe] (mi|\s)? ?almuerzo/i,
         command: true, help: help_msg(:sell_lunch)) do |response|
         user = response.user
-        order = create_order(user, 'limit')
+        order = create_order(user, 'ask')
         unless winning_list.include?(user.mention_name)
           response.reply("@#{user.mention_name} #{t(:cant_sell)}")
           next
@@ -208,8 +208,8 @@ module Lita
       route(/c(o|ó)mpr(o|ame|a)? (un )?almuerzo/i,
         command: true, help: help_msg(:buy_lunch)) do |response|
         user = response.user
-        order = @market.add_market_order(user.id)
-        unless order
+        order = create_order(user, 'bid')
+        if winning_list.include?(user.mention_name)
           response.reply(t(:cant_buy))
           next
         end

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -296,6 +296,10 @@ module Lita
         bid_order = executed_orders[:bid]
         seller_user = Lita::User.find_by_id(ask_order[:user_id])
         buyer_user = Lita::User.find_by_id(bid_order[:user_id])
+        notify_transaction(buyer_user, seller_user)
+      end
+
+      def notify_transaction(buyer_user, seller_user)
         seller_message = "@#{seller_user.mention_name}, #{t(:sold_lunch)}"
         buyer_message = "@#{buyer_user.mention_name}, #{t(:bought_lunch)}"
         robot.send_message(Source.new(user: seller_user), seller_message) if seller_user

--- a/lib/lita/services/market_manager.rb
+++ b/lib/lita/services/market_manager.rb
@@ -53,14 +53,18 @@ module Lita
         order
       end
 
-      def remove_order
-        return if orders.empty?
-        new_orders = orders
+      def remove_orders
+        new_ask_orders = ask_orders
+        new_bid_orders = ask_orders
+        return if new_ask_orders.empty? || new_bid_orders.empty?
         reset_limit_orders
-        new_orders[1..-1].each do |order|
+        new_ask_orders[1..-1].each do |order|
           @redis.sadd('orders', order.to_json)
         end
-        new_orders.first
+        new_bid_orders[1..-1].each do |order|
+          @redis.sadd('orders', order.to_json)
+        end
+        { 'ask': new_ask_orders.first, 'bid': new_bid_orders }
       end
 
       def reset_limit_orders

--- a/lib/lita/services/market_manager.rb
+++ b/lib/lita/services/market_manager.rb
@@ -70,6 +70,15 @@ module Lita
       def reset_limit_orders
         @redis.del('orders')
       end
+
+      def execute_transaction
+        orders = remove_orders
+        return unless orders
+        lunch_seller = Lita::User.find_by_id(orders['ask']['user_id'])
+        lunch_buyer = Lita::User.find_by_id(orders['bid']['user_id'])
+        @karmanager.transfer_karma(lunch_buyer.id, lunch_seller.id, 1)
+        @lunch_assigner.transfer_lunch(lunch_seller.mention_name, lunch_buyer.mention_name)
+      end
     end
   end
 end

--- a/lib/lita/services/market_manager.rb
+++ b/lib/lita/services/market_manager.rb
@@ -71,9 +71,7 @@ module Lita
       end
 
       def transaction_possible?
-        new_ask_orders = ask_orders
-        new_bid_orders = bid_orders
-        return true unless new_ask_orders.empty? || new_bid_orders.empty?
+        ask_orders.any? && bid_orders.any?
       end
     end
   end

--- a/lib/lita/services/market_manager.rb
+++ b/lib/lita/services/market_manager.rb
@@ -61,13 +61,19 @@ module Lita
       end
 
       def execute_transaction
+        return unless transaction_possible?
         executed_orders = remove_orders
-        return if executed_orders.nil?
         lunch_seller = Lita::User.find_by_id(executed_orders[:ask]['user_id'])
         lunch_buyer = Lita::User.find_by_id(executed_orders[:bid]['user_id'])
         @karmanager.transfer_karma(lunch_buyer.id, lunch_seller.id, 1)
         @lunch_assigner.transfer_lunch(lunch_seller.mention_name, lunch_buyer.mention_name)
         executed_orders
+      end
+
+      def transaction_possible?
+        new_ask_orders = ask_orders
+        new_bid_orders = bid_orders
+        return true unless new_ask_orders.empty? || new_bid_orders.empty?
       end
     end
   end

--- a/lib/lita/services/market_manager.rb
+++ b/lib/lita/services/market_manager.rb
@@ -42,20 +42,9 @@ module Lita
         orders.map { |order| order['user_id'] }.include? user_id
       end
 
-      def add_market_order(lunch_buyer_id)
-        return unless @karmanager.get_karma(lunch_buyer_id) > 0
-        order = remove_order
-        return if order.nil?
-        lunch_seller = Lita::User.find_by_id(order['user_id'])
-        lunch_buyer = Lita::User.find_by_id(lunch_buyer_id)
-        @karmanager.transfer_karma(lunch_buyer.id, lunch_seller.id, 1)
-        @lunch_assigner.transfer_lunch(lunch_seller.mention_name, lunch_buyer.mention_name)
-        order
-      end
-
       def remove_orders
         new_ask_orders = ask_orders
-        new_bid_orders = ask_orders
+        new_bid_orders = bid_orders
         return if new_ask_orders.empty? || new_bid_orders.empty?
         reset_limit_orders
         new_ask_orders[1..-1].each do |order|
@@ -64,7 +53,7 @@ module Lita
         new_bid_orders[1..-1].each do |order|
           @redis.sadd('orders', order.to_json)
         end
-        { 'ask': new_ask_orders.first, 'bid': new_bid_orders }
+        { 'ask': new_ask_orders.first, 'bid': new_bid_orders.first }
       end
 
       def reset_limit_orders
@@ -72,12 +61,13 @@ module Lita
       end
 
       def execute_transaction
-        orders = remove_orders
-        return unless orders
-        lunch_seller = Lita::User.find_by_id(orders['ask']['user_id'])
-        lunch_buyer = Lita::User.find_by_id(orders['bid']['user_id'])
+        executed_orders = remove_orders
+        return if executed_orders.nil?
+        lunch_seller = Lita::User.find_by_id(executed_orders[:ask]['user_id'])
+        lunch_buyer = Lita::User.find_by_id(executed_orders[:bid]['user_id'])
         @karmanager.transfer_karma(lunch_buyer.id, lunch_seller.id, 1)
         @lunch_assigner.transfer_lunch(lunch_seller.mention_name, lunch_buyer.mention_name)
+        executed_orders
       end
     end
   end

--- a/lib/lita/services/market_manager.rb
+++ b/lib/lita/services/market_manager.rb
@@ -19,6 +19,20 @@ module Lita
               .sort { |x, y| Time.parse(x['created_at']) <=> Time.parse(y['created_at']) }
       end
 
+      def ask_orders
+        orders = @redis.smembers('orders') || []
+        orders.map { |order| JSON.parse(order) }
+              .select { |z| z.type == 'ask' }
+              .sort { |x, y| Time.parse(x['created_at']) <=> Time.parse(y['created_at']) }
+      end
+
+      def bid_orders
+        orders = @redis.smembers('orders') || []
+        orders.map { |order| JSON.parse(order) }
+              .select { |z| z.type == 'bid' }
+              .sort { |x, y| Time.parse(x['created_at']) <=> Time.parse(y['created_at']) }
+      end
+
       def add_limit_order(new_order)
         return if placed_limit_order?(JSON.parse(new_order)['user_id'])
         @redis.sadd('orders', new_order)

--- a/lib/lita/services/market_manager.rb
+++ b/lib/lita/services/market_manager.rb
@@ -22,14 +22,14 @@ module Lita
       def ask_orders
         orders = @redis.smembers('orders') || []
         orders.map { |order| JSON.parse(order) }
-              .select { |z| z.type == 'ask' }
+              .select { |z| z['type'] == 'ask' }
               .sort { |x, y| Time.parse(x['created_at']) <=> Time.parse(y['created_at']) }
       end
 
       def bid_orders
         orders = @redis.smembers('orders') || []
         orders.map { |order| JSON.parse(order) }
-              .select { |z| z.type == 'bid' }
+              .select { |z| z['type'] == 'bid' }
               .sort { |x, y| Time.parse(x['created_at']) <=> Time.parse(y['created_at']) }
       end
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -25,7 +25,9 @@ en:
         dinner_is_served: "Está listo amiguito, *suba* a almorzar ;)"
         friend_added: "Perfecto @%{subject}, anoté a tu invitado como invitado_de_%{subject}."
         selling_lunch: 'tengo tu almuerzo en venta!'
+        buying_lunch: 'voy a tratar de conseguirte almuerzo!'
         bought_lunch: 'ya te conseguí almuerzo!'
+        sold_lunch: 'ya te vendí almuerzo!'
         transaction: "@%{subject1} le compró almuerzo a @%{subject2}"
         cant_buy: 'no te puedo comprar almuerzo...'
         cant_sell: 'no puedes vender algo que no tienes!'

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -25,7 +25,9 @@ es:
         dinner_is_served: "Está listo amiguito, *suba* a almorzar ;)"
         friend_added: "Perfecto @%{subject}, anoté a tu invitado como invitado_de_%{subject}."
         selling_lunch: 'tengo tu almuerzo en venta!'
+        buying_lunch: 'voy a tratar de conseguirte almuerzo!'
         bought_lunch: 'ya te conseguí almuerzo!'
+        sold_lunch: 'ya te vendí almuerzo!'
         transaction: "@%{subject1} le compró almuerzo a @%{subject2}"
         cant_buy: 'no te puedo comprar almuerzo...'
         cant_sell: 'no puedes vender algo que no tienes!'

--- a/spec/lita/handlers/api/market_spec.rb
+++ b/spec/lita/handlers/api/market_spec.rb
@@ -23,8 +23,8 @@ describe Lita::Handlers::Api::Market, lita_handler: true do
   end
 
   it { is_expected.to route_http(:get, 'market/limit_orders') }
-  it { is_expected.to route_http(:get, 'market/execute_transaction') }
   it { is_expected.to route_http(:post, 'market/limit_orders') }
+  it { is_expected.to route_http(:post, 'market/execute_transaction') }
 
   before do
     ENV['MAX_LUNCHERS'] = '20'

--- a/spec/lita/handlers/api/market_spec.rb
+++ b/spec/lita/handlers/api/market_spec.rb
@@ -24,7 +24,6 @@ describe Lita::Handlers::Api::Market, lita_handler: true do
 
   it { is_expected.to route_http(:get, 'market/limit_orders') }
   it { is_expected.to route_http(:post, 'market/limit_orders') }
-  it { is_expected.to route_http(:post, 'market/market_orders') }
 
   before do
     ENV['MAX_LUNCHERS'] = '20'
@@ -99,32 +98,6 @@ describe Lita::Handlers::Api::Market, lita_handler: true do
         expect(order['id']).not_to be_nil
         expect(order['type']).to eq('limit')
         expect(order['created_at']).not_to be_nil
-      end
-    end
-  end
-
-  describe 'POST market order' do
-    context 'not authorized' do
-      it 'responds with not autorized' do
-        response = JSON.parse(http.post('market/market_orders').body)
-        expect(response['status']).to eq(401)
-        expect(response['message']).to eq('Not authorized')
-      end
-    end
-
-    context 'authorized' do
-      before do
-        allow_any_instance_of(Lita::Handlers::Api::Market).to receive(:authorized?).and_return(true)
-        allow(market).to receive(:add_market_order).and_return(true)
-        allow(winning_list).to receive(:include?).and_return(false)
-      end
-
-      it 'responds with success' do
-        response = JSON.parse(http.post do |req|
-          req.url 'market/market_orders'
-          req.body = market_order.to_s
-        end.body)
-        expect(response['success']).to eq(true)
       end
     end
   end

--- a/spec/lita/handlers/api/market_spec.rb
+++ b/spec/lita/handlers/api/market_spec.rb
@@ -69,7 +69,7 @@ describe Lita::Handlers::Api::Market, lita_handler: true do
   describe '#execute_transaction' do
     context 'not authorized' do
       it 'responds with not autorized' do
-        response = JSON.parse(http.get('market/execute_transaction').body)
+        response = JSON.parse(http.post('market/execute_transaction').body)
         expect(response['status']).to eq(401)
         expect(response['message']).to eq('Not authorized')
       end
@@ -88,7 +88,7 @@ describe Lita::Handlers::Api::Market, lita_handler: true do
       end
 
       it 'includes both orders' do
-        response = JSON.parse(http.get('market/execute_transaction').body)
+        response = JSON.parse(http.post('market/execute_transaction').body)
         expect(JSON.parse(response['orders'])['ask'].to_json).to eq(ask_order.to_json)
         expect(JSON.parse(response['orders'])['bid'].to_json).to eq(bid_order.to_json)
       end

--- a/spec/lita/handlers/api/market_spec.rb
+++ b/spec/lita/handlers/api/market_spec.rb
@@ -7,7 +7,7 @@ describe Lita::Handlers::Api::Market, lita_handler: true do
   let(:user) { double }
   let(:order_id) { SecureRandom.uuid }
   let(:time) { Time.now }
-  let(:limit_order) { { id: order_id, user_id: 127, type: 'sell', created_at: time } }
+  let(:limit_order) { { id: order_id, user_id: 127, type: 'ask', created_at: time } }
   let(:market_order) { { user_id: '127' } }
   let(:winning_list) { [user] }
 
@@ -50,7 +50,7 @@ describe Lita::Handlers::Api::Market, lita_handler: true do
     end
 
     context 'authorized' do
-      let(:limit_order) { { id: order_id, user_id: 127, type: 'sell', created_at: time } }
+      let(:limit_order) { { id: order_id, user_id: 127, type: 'ask', created_at: time } }
       before do
         allow_any_instance_of(Lita::Handlers::Api::Market).to receive(:authorized?).and_return(true)
         allow_any_instance_of(Lita::Handlers::Api::Market)
@@ -96,7 +96,7 @@ describe Lita::Handlers::Api::Market, lita_handler: true do
         order = JSON.parse(response['order'])
         expect(order).not_to be_nil
         expect(order['id']).not_to be_nil
-        expect(order['type']).to eq('limit')
+        expect(order['type']).to eq('ask')
         expect(order['created_at']).not_to be_nil
       end
     end

--- a/spec/lita/handlers/lunch_reminder_spec.rb
+++ b/spec/lita/handlers/lunch_reminder_spec.rb
@@ -89,31 +89,30 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
   end
 
   describe 'buy lunch' do
-    context 'user can place limit order' do
-      let(:user) { double(mention_name: 'felipe.dominguez') }
-      let(:lita_user) { Lita::User }
-      let!(:user2) { Lita::User.create(124, mention_name: 'armando') }
-      before do
-        allow_any_instance_of(Lita::Services::MarketManager).to \
-          receive(:add_limit_order).and_return(true)
-        allow(lita_user).to receive(:find_by_id).and_return(user)
-        allow(lita_user).to receive(:create).and_return(user2)
-      end
-      it 'responds that limit order was placed' do
-        armando = Lita::User.create(124, mention_name: 'armando')
-        send_message('@lita compro almuerzo', as: armando)
-        expect(replies.last).to match('@armando le compró almuerzo a @felipe.dominguez')
-      end
-    end
-    context "user cant' place limit order" do
+    context 'user has lunch' do
       before do
         allow_any_instance_of(Lita::Services::MarketManager).to\
-          receive(:add_market_order).and_return(false)
+          receive(:add_limit_order).and_return(false)
+        allow_any_instance_of(Lita::Services::LunchAssigner).to\
+          receive(:winning_lunchers_list).and_return(['armando'])
       end
       it 'responds with an error' do
         armando = Lita::User.create(124, mention_name: 'armando')
         send_message('@lita compro almuerzo', as: armando)
         expect(replies.last).to match('no te puedo comprar almuerzo...')
+      end
+    end
+    context 'user without lunch' do
+      before do
+        allow_any_instance_of(Lita::Services::MarketManager).to\
+          receive(:add_limit_order).and_return(true)
+        allow_any_instance_of(Lita::Services::LunchAssigner).to\
+          receive(:winning_lunchers_list).and_return([])
+      end
+      it 'responds that limit order was placed' do
+        armando = Lita::User.create(124, mention_name: 'armando')
+        send_message('@lita compro almuerzo', as: armando)
+        expect(replies.last).to match('tengo tu almuerzo en venta!')
       end
     end
   end

--- a/spec/lita/handlers/lunch_reminder_spec.rb
+++ b/spec/lita/handlers/lunch_reminder_spec.rb
@@ -59,7 +59,7 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
     expect(replies.last).to match('Tienes 1 puntos de karma, mi padawan')
   end
 
-  describe 'place limit order' do
+  describe 'sell lunch' do
     context 'user has lunch' do
       before do
         allow_any_instance_of(Lita::Services::MarketManager).to\
@@ -88,24 +88,24 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
     end
   end
 
-  describe 'place market order' do
-    context 'user can place market order' do
+  describe 'buy lunch' do
+    context 'user can place limit order' do
       let(:user) { double(mention_name: 'felipe.dominguez') }
       let(:lita_user) { Lita::User }
       let!(:user2) { Lita::User.create(124, mention_name: 'armando') }
       before do
         allow_any_instance_of(Lita::Services::MarketManager).to \
-          receive(:add_market_order).and_return('user_id': 123)
+          receive(:add_limit_order).and_return(true)
         allow(lita_user).to receive(:find_by_id).and_return(user)
         allow(lita_user).to receive(:create).and_return(user2)
       end
-      it 'responds that market order was placed' do
+      it 'responds that limit order was placed' do
         armando = Lita::User.create(124, mention_name: 'armando')
         send_message('@lita compro almuerzo', as: armando)
         expect(replies.last).to match('@armando le compró almuerzo a @felipe.dominguez')
       end
     end
-    context "user cant' place market order" do
+    context "user cant' place limit order" do
       before do
         allow_any_instance_of(Lita::Services::MarketManager).to\
           receive(:add_market_order).and_return(false)

--- a/spec/lita/handlers/lunch_reminder_spec.rb
+++ b/spec/lita/handlers/lunch_reminder_spec.rb
@@ -89,8 +89,8 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
         before do
           allow_any_instance_of(Lita::Services::MarketManager).to \
             receive(:execute_transaction).and_return(orders)
-            allow(lita_user).to receive(:find_by_id).with(123).and_return(user)
-            allow(lita_user).to receive(:find_by_id).with(124).and_return(user2)
+          allow(lita_user).to receive(:find_by_id).with(123).and_return(user)
+          allow(lita_user).to receive(:find_by_id).with(124).and_return(user2)
           allow(lita_user).to receive(:create).and_return(user2)
         end
 

--- a/spec/lita/handlers/lunch_reminder_spec.rb
+++ b/spec/lita/handlers/lunch_reminder_spec.rb
@@ -61,6 +61,44 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
 
   describe 'sell lunch' do
     context 'user has lunch' do
+      context 'no ask orders placed' do
+        before do
+          allow_any_instance_of(Lita::Services::MarketManager).to\
+            receive(:add_limit_order).and_return(true)
+          allow_any_instance_of(Lita::Services::LunchAssigner).to\
+            receive(:winning_lunchers_list).and_return(['armando'])
+        end
+        it 'responds that limit order was placed' do
+          armando = Lita::User.create(124, mention_name: 'armando')
+          send_message('@lita vendo almuerzo', as: armando)
+          expect(replies.last).to match('tengo tu almuerzo en venta!')
+        end
+      end
+
+      context 'one or more ask orders placed' do
+        let(:ask_order) { { 'id': 1111, 'user_id': 123, 'type': 'ask' } }
+        let(:bid_order) { { 'id': 2222, 'user_id': 124, 'type': 'bid' } }
+        let(:orders) { { 'ask': ask_order, 'bid': bid_order } }
+
+        let(:user) { double(mention_name: 'felipe.dominguez') }
+        let(:lita_user) { Lita::User }
+        let!(:user2) { Lita::User.create(124, mention_name: 'armando') }
+
+        before do
+          allow_any_instance_of(Lita::Services::MarketManager).to \
+            receive(:execute_transaction).and_return(orders)
+          allow(lita_user).to receive(:find_by_id).and_return(user)
+          allow(lita_user).to receive(:create).and_return(user2)
+        end
+
+        it 'responds with transaction' do
+          armando = Lita::User.create(124, mention_name: 'armando')
+          send_message('@lita compro almuerzo', as: armando)
+          expect(replies.last).to match('@armando le compró almuerzo a @felipe.dominguez')
+        end
+      end
+
+
       before do
         allow_any_instance_of(Lita::Services::MarketManager).to\
           receive(:add_limit_order).and_return(true)
@@ -102,17 +140,43 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
         expect(replies.last).to match('no te puedo comprar almuerzo...')
       end
     end
+
     context 'user without lunch' do
-      before do
-        allow_any_instance_of(Lita::Services::MarketManager).to\
-          receive(:add_limit_order).and_return(true)
-        allow_any_instance_of(Lita::Services::LunchAssigner).to\
-          receive(:winning_lunchers_list).and_return([])
+      context 'no ask orders placed' do
+        before do
+          allow_any_instance_of(Lita::Services::MarketManager).to\
+            receive(:add_limit_order).and_return(true)
+          allow_any_instance_of(Lita::Services::LunchAssigner).to\
+            receive(:winning_lunchers_list).and_return([])
+        end
+        it 'responds that limit order was placed' do
+          armando = Lita::User.create(124, mention_name: 'armando')
+          send_message('@lita compro almuerzo', as: armando)
+          expect(replies.last).to match('voy a tratar de conseguirte almuerzo!')
+        end
       end
-      it 'responds that limit order was placed' do
-        armando = Lita::User.create(124, mention_name: 'armando')
-        send_message('@lita compro almuerzo', as: armando)
-        expect(replies.last).to match('tengo tu almuerzo en venta!')
+
+      context 'one or more ask orders placed' do
+        let(:ask_order) { { 'id': 1111, 'user_id': 123, 'type': 'ask' } }
+        let(:bid_order) { { 'id': 2222, 'user_id': 124, 'type': 'bid' } }
+        let(:orders) { { 'ask': ask_order, 'bid': bid_order } }
+
+        let(:user) { double(mention_name: 'felipe.dominguez') }
+        let(:lita_user) { Lita::User }
+        let!(:user2) { Lita::User.create(124, mention_name: 'armando') }
+
+        before do
+          allow_any_instance_of(Lita::Services::MarketManager).to \
+            receive(:execute_transaction).and_return(orders)
+          allow(lita_user).to receive(:find_by_id).and_return(user)
+          allow(lita_user).to receive(:create).and_return(user2)
+        end
+
+        it 'responds with transaction' do
+          armando = Lita::User.create(124, mention_name: 'armando')
+          send_message('@lita compro almuerzo', as: armando)
+          expect(replies.last).to match('@armando le compró almuerzo a @felipe.dominguez')
+        end
       end
     end
   end

--- a/spec/lita/handlers/lunch_reminder_spec.rb
+++ b/spec/lita/handlers/lunch_reminder_spec.rb
@@ -61,12 +61,14 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
 
   describe 'sell lunch' do
     context 'user has lunch' do
+      before do
+        allow_any_instance_of(Lita::Services::LunchAssigner).to\
+          receive(:winning_lunchers_list).and_return(['armando'])
+      end
       context 'no ask orders placed' do
         before do
           allow_any_instance_of(Lita::Services::MarketManager).to\
             receive(:add_limit_order).and_return(true)
-          allow_any_instance_of(Lita::Services::LunchAssigner).to\
-            receive(:winning_lunchers_list).and_return(['armando'])
         end
         it 'responds that limit order was placed' do
           armando = Lita::User.create(124, mention_name: 'armando')
@@ -87,30 +89,19 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
         before do
           allow_any_instance_of(Lita::Services::MarketManager).to \
             receive(:execute_transaction).and_return(orders)
-          allow(lita_user).to receive(:find_by_id).and_return(user)
+            allow(lita_user).to receive(:find_by_id).with(123).and_return(user)
+            allow(lita_user).to receive(:find_by_id).with(124).and_return(user2)
           allow(lita_user).to receive(:create).and_return(user2)
         end
 
         it 'responds with transaction' do
           armando = Lita::User.create(124, mention_name: 'armando')
-          send_message('@lita compro almuerzo', as: armando)
+          send_message('@lita vendo almuerzo', as: armando)
           expect(replies.last).to match('@armando le compró almuerzo a @felipe.dominguez')
         end
       end
-
-
-      before do
-        allow_any_instance_of(Lita::Services::MarketManager).to\
-          receive(:add_limit_order).and_return(true)
-        allow_any_instance_of(Lita::Services::LunchAssigner).to\
-          receive(:winning_lunchers_list).and_return(['armando'])
-      end
-      it 'responds that limit order was placed' do
-        armando = Lita::User.create(124, mention_name: 'armando')
-        send_message('@lita vende mi almuerzo', as: armando)
-        expect(replies.last).to match('tengo tu almuerzo en venta!')
-      end
     end
+
     context 'user without lunch' do
       before do
         allow_any_instance_of(Lita::Services::MarketManager).to\
@@ -168,7 +159,8 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
         before do
           allow_any_instance_of(Lita::Services::MarketManager).to \
             receive(:execute_transaction).and_return(orders)
-          allow(lita_user).to receive(:find_by_id).and_return(user)
+          allow(lita_user).to receive(:find_by_id).with(123).and_return(user)
+          allow(lita_user).to receive(:find_by_id).with(124).and_return(user2)
           allow(lita_user).to receive(:create).and_return(user2)
         end
 

--- a/spec/lita/handlers/lunch_reminder_spec.rb
+++ b/spec/lita/handlers/lunch_reminder_spec.rb
@@ -65,7 +65,7 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
         allow_any_instance_of(Lita::Services::LunchAssigner).to\
           receive(:winning_lunchers_list).and_return(['armando'])
       end
-      context 'no ask orders placed' do
+      context 'no bid orders placed' do
         before do
           allow_any_instance_of(Lita::Services::MarketManager).to\
             receive(:add_limit_order).and_return(true)
@@ -77,7 +77,7 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
         end
       end
 
-      context 'one or more ask orders placed' do
+      context 'one or more bid orders placed' do
         let(:ask_order) { { 'id': 1111, 'user_id': 123, 'type': 'ask' } }
         let(:bid_order) { { 'id': 2222, 'user_id': 124, 'type': 'bid' } }
         let(:orders) { { 'ask': ask_order, 'bid': bid_order } }
@@ -128,7 +128,7 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
       it 'responds with an error' do
         armando = Lita::User.create(124, mention_name: 'armando')
         send_message('@lita compro almuerzo', as: armando)
-        expect(replies.last).to match('no te puedo comprar almuerzo...')
+        expect(replies.last).to match('@armando no te puedo comprar almuerzo...')
       end
     end
 

--- a/spec/lita/services/market_manager_spec.rb
+++ b/spec/lita/services/market_manager_spec.rb
@@ -309,11 +309,24 @@ describe Lita::Services::MarketManager, lita: true do
   end
 
   describe '#execute_transaction' do
-    before do
-      let(:ask_order) { add_limit_order(SecureRandom.uuid, andres, 'ask', Time.new(2018, 10, 5)) }
-      let(:bid_order) { add_limit_order(SecureRandom.uuid, fdom, 'bid', Time.new(2018, 10, 3)) }
+    context 'exists one order' do
+      before do
+        let(:ask_order) { add_limit_order(SecureRandom.uuid, andres, 'ask', Time.new(2018, 10, 5)) }
+        subject.execute_transaction
+      end
+
+      it { expect(subject.ask_orders.size).to eq(1) }
     end
 
-    it { expect(subject.execute_transaction).to eq('ask': ask_order, 'bid': bid_order) }
+    context 'exists two or more orders' do
+      before do
+        let(:ask_order) { add_limit_order(SecureRandom.uuid, andres, 'ask', Time.new(2018, 10, 5)) }
+        let(:bid_order) { add_limit_order(SecureRandom.uuid, fdom, 'bid', Time.new(2018, 10, 3)) }
+        subject.execute_transaction
+      end
+
+      it { expect(subject.ask_orders.size).to eq(0) }
+      it { expect(subject.bid_orders.size).to eq(0) }
+    end
   end
 end

--- a/spec/lita/services/market_manager_spec.rb
+++ b/spec/lita/services/market_manager_spec.rb
@@ -307,4 +307,13 @@ describe Lita::Services::MarketManager, lita: true do
 
     it { expect(subject.orders.size).to eq(0) }
   end
+
+  describe '#execute_transaction' do
+    before do
+      let(:ask_order) { add_limit_order(SecureRandom.uuid, andres, 'ask', Time.new(2018, 10, 5)) }
+      let(:bid_order) { add_limit_order(SecureRandom.uuid, fdom, 'bid', Time.new(2018, 10, 3)) }
+    end
+
+    it { expect(subject.execute_transaction).to eq('ask': ask_order, 'bid': bid_order) }
+  end
 end

--- a/spec/lita/services/market_manager_spec.rb
+++ b/spec/lita/services/market_manager_spec.rb
@@ -162,6 +162,35 @@ describe Lita::Services::MarketManager, lita: true do
     end
   end
 
+  describe '#ask_orders' do
+    context 'without orders' do
+      it { expect(subject.ask_orders.size).to eq(0) }
+    end
+
+    context 'with one order' do
+      before do
+        add_limit_order(SecureRandom.uuid, andres, 'ask', Time.now)
+      end
+
+      it { expect(subject.ask_orders.size).to eq(1) }
+    end
+
+    context 'with more than one order' do
+      before do
+        add_limit_order(SecureRandom.uuid, andres, 'ask', Time.new(2018, 10, 5))
+        add_limit_order(SecureRandom.uuid, fdom, 'ask', Time.new(2018, 10, 3))
+        add_limit_order(SecureRandom.uuid, oscar, 'ask', Time.new(2018, 10, 4))
+      end
+
+      it { expect(subject.orders.size).to eq(3) }
+      it 'sorts orders by date' do
+        expect(subject.ask_orders[0]['user_id']).to eq(fdom.id)
+        expect(subject.ask_orders[1]['user_id']).to eq(oscar.id)
+        expect(subject.ask_orders[2]['user_id']).to eq(andres.id)
+      end
+    end
+  end
+
   describe '#add_market_order' do
     context 'user with karma' do
       before do

--- a/spec/lita/services/market_manager_spec.rb
+++ b/spec/lita/services/market_manager_spec.rb
@@ -52,44 +52,44 @@ describe Lita::Services::MarketManager, lita: true do
   describe '#add_limit_order' do
     context 'first order added' do
       before do
-        add_limit_order(order_id, fdom, 'sell', order_time)
+        add_limit_order(order_id, fdom, 'ask', order_time)
       end
 
       it 'adds order to limit orders' do
-        add_limit_order(order_id, fdom, 'sell', order_time)
+        add_limit_order(order_id, fdom, 'ask', order_time)
         expect(subject.orders.last).not_to be_nil
       end
 
       it 'adds the correct limit order' do
-        add_limit_order(order_id, fdom, 'sell', order_time)
+        add_limit_order(order_id, fdom, 'ask', order_time)
         expect(subject.orders.last['id']).to eq(order_id)
       end
     end
 
     context 'with non empty orders' do
       before do
-        add_limit_order(SecureRandom.uuid, andres, 'sell', Time.new(2018, 10, 2))
+        add_limit_order(SecureRandom.uuid, andres, 'ask', Time.new(2018, 10, 2))
       end
 
       it 'adds limit order' do
-        add_limit_order(order_id, fdom, 'sell', order_time)
+        add_limit_order(order_id, fdom, 'ask', order_time)
         expect(subject.orders.last).not_to be_nil
       end
 
       it 'sorts orders by date' do
-        add_limit_order(order_id, fdom, 'sell', order_time)
+        add_limit_order(order_id, fdom, 'ask', order_time)
         expect(subject.orders.last['user_id']).to eq(fdom.id)
         expect(subject.orders.last['id']).to eq(order_id)
-        expect(subject.orders.last['type']).to eq('sell')
+        expect(subject.orders.last['type']).to eq('ask')
         expect(subject.orders.last['created_at']).to eq(order_time.strftime('%F %T %z'))
       end
     end
 
     context 'user already has an order' do
       let(:old_order_id) { SecureRandom.uuid }
-      let(:new_order) { add_limit_order(SecureRandom.uuid, fdom, 'sell', Time.now) }
+      let(:new_order) { add_limit_order(SecureRandom.uuid, fdom, 'ask', Time.now) }
       before do
-        add_limit_order(old_order_id, fdom, 'sell', order_time)
+        add_limit_order(old_order_id, fdom, 'ask', order_time)
         allow(subject).to receive(:placed_limit_order?).with(fdom.id).and_return true
       end
 
@@ -99,17 +99,17 @@ describe Lita::Services::MarketManager, lita: true do
       end
 
       it "doesn't edit list" do
-        add_limit_order(SecureRandom.uuid, fdom, 'sell', order_time)
+        add_limit_order(SecureRandom.uuid, fdom, 'ask', order_time)
         expect(subject.orders.first['id']).to eq(old_order_id)
       end
 
       it 'calls placed_limit_order?' do
-        add_limit_order(SecureRandom.uuid, fdom, 'sell', order_time)
+        add_limit_order(SecureRandom.uuid, fdom, 'ask', order_time)
         expect(subject).to have_received(:placed_limit_order?).with(fdom.id)
       end
 
       it 'placed_limit_order? returns true' do
-        add_limit_order(SecureRandom.uuid, fdom, 'sell', order_time)
+        add_limit_order(SecureRandom.uuid, fdom, 'ask', order_time)
         expect(subject.placed_limit_order?(fdom.id)).to eq(true)
       end
     end
@@ -118,7 +118,7 @@ describe Lita::Services::MarketManager, lita: true do
   describe '#placed_limit_order?' do
     context 'user already has an order' do
       before do
-        add_limit_order(SecureRandom.uuid, fdom, 'sell', Time.now)
+        add_limit_order(SecureRandom.uuid, fdom, 'ask', Time.now)
       end
 
       it { expect(subject.placed_limit_order?(fdom.id)).to be true }
@@ -126,7 +126,7 @@ describe Lita::Services::MarketManager, lita: true do
 
     context "user doesn't have an order" do
       before do
-        add_limit_order(SecureRandom.uuid, andres, 'sell', Time.now)
+        add_limit_order(SecureRandom.uuid, andres, 'ask', Time.now)
       end
 
       it { expect(subject.placed_limit_order?(fdom.id)).to be false }
@@ -140,7 +140,7 @@ describe Lita::Services::MarketManager, lita: true do
 
     context 'with one order' do
       before do
-        add_limit_order(SecureRandom.uuid, andres, 'sell', Time.now)
+        add_limit_order(SecureRandom.uuid, andres, 'ask', Time.now)
       end
 
       it { expect(subject.orders.size).to eq(1) }
@@ -148,9 +148,9 @@ describe Lita::Services::MarketManager, lita: true do
 
     context 'with more than one order' do
       before do
-        add_limit_order(SecureRandom.uuid, andres, 'sell', Time.new(2018, 10, 5))
-        add_limit_order(SecureRandom.uuid, fdom, 'sell', Time.new(2018, 10, 3))
-        add_limit_order(SecureRandom.uuid, oscar, 'sell', Time.new(2018, 10, 4))
+        add_limit_order(SecureRandom.uuid, andres, 'ask', Time.new(2018, 10, 5))
+        add_limit_order(SecureRandom.uuid, fdom, 'ask', Time.new(2018, 10, 3))
+        add_limit_order(SecureRandom.uuid, oscar, 'ask', Time.new(2018, 10, 4))
       end
 
       it { expect(subject.orders.size).to eq(3) }
@@ -174,7 +174,7 @@ describe Lita::Services::MarketManager, lita: true do
 
       context 'exists one order' do
         before do
-          add_limit_order(SecureRandom.uuid, andres, 'sell', Time.now)
+          add_limit_order(SecureRandom.uuid, andres, 'ask', Time.now)
           subject.add_market_order(fdom.id)
         end
 
@@ -184,9 +184,9 @@ describe Lita::Services::MarketManager, lita: true do
       context 'exists more than one order' do
         before do
           setup_lunchers
-          add_limit_order(SecureRandom.uuid, andres, 'sell', Time.new(2018, 10, 5))
-          add_limit_order(SecureRandom.uuid, fdom, 'sell', Time.new(2018, 10, 3))
-          add_limit_order(SecureRandom.uuid, oscar, 'sell', Time.new(2018, 10, 4))
+          add_limit_order(SecureRandom.uuid, andres, 'ask', Time.new(2018, 10, 5))
+          add_limit_order(SecureRandom.uuid, fdom, 'ask', Time.new(2018, 10, 3))
+          add_limit_order(SecureRandom.uuid, oscar, 'ask', Time.new(2018, 10, 4))
           karmanager.set_karma(fdom.id, 100)
           karmanager.set_karma(fernanda.id, 100)
         end
@@ -207,7 +207,7 @@ describe Lita::Services::MarketManager, lita: true do
           expect(lunch_assigner.winning_lunchers_list).to include(fernanda.mention_name)
         end
 
-        it 'transfers karma from buyer to seller' do
+        it 'transfers karma from buyer to asker' do
           karma_fdom = karmanager.get_karma(fdom.id)
           karma_fernanda = karmanager.get_karma(fernanda.id)
           subject.add_market_order(fernanda.id)
@@ -228,7 +228,7 @@ describe Lita::Services::MarketManager, lita: true do
 
       context 'exists one order' do
         before do
-          add_limit_order(SecureRandom.uuid, andres, 'sell', Time.now)
+          add_limit_order(SecureRandom.uuid, andres, 'ask', Time.now)
         end
 
         it "doesn't place market order" do
@@ -241,9 +241,9 @@ describe Lita::Services::MarketManager, lita: true do
 
   describe '#reset_limit_orders' do
     before do
-      add_limit_order(SecureRandom.uuid, andres, 'sell', Time.new(2018, 10, 5))
-      add_limit_order(SecureRandom.uuid, fdom, 'sell', Time.new(2018, 10, 3))
-      add_limit_order(SecureRandom.uuid, oscar, 'sell', Time.new(2018, 10, 4))
+      add_limit_order(SecureRandom.uuid, andres, 'ask', Time.new(2018, 10, 5))
+      add_limit_order(SecureRandom.uuid, fdom, 'ask', Time.new(2018, 10, 3))
+      add_limit_order(SecureRandom.uuid, oscar, 'ask', Time.new(2018, 10, 4))
       subject.reset_limit_orders
     end
 

--- a/spec/lita/services/market_manager_spec.rb
+++ b/spec/lita/services/market_manager_spec.rb
@@ -303,9 +303,9 @@ describe Lita::Services::MarketManager, lita: true do
     end
 
     context 'transaction not possible' do
-      it 'returns nil' do
+      it 'returns false' do
         add_limit_order(SecureRandom.uuid, oscar, 'ask', Time.new(2018, 10, 5))
-        expect(subject.transaction_possible?).to be(nil)
+        expect(subject.transaction_possible?).to be(false)
       end
     end
   end

--- a/spec/lita/services/market_manager_spec.rb
+++ b/spec/lita/services/market_manager_spec.rb
@@ -191,6 +191,35 @@ describe Lita::Services::MarketManager, lita: true do
     end
   end
 
+  describe '#bid_orders' do
+    context 'without orders' do
+      it { expect(subject.bid_orders.size).to eq(0) }
+    end
+
+    context 'with one order' do
+      before do
+        add_limit_order(SecureRandom.uuid, andres, 'bid', Time.now)
+      end
+
+      it { expect(subject.bid_orders.size).to eq(1) }
+    end
+
+    context 'with more than one order' do
+      before do
+        add_limit_order(SecureRandom.uuid, andres, 'bid', Time.new(2018, 10, 5))
+        add_limit_order(SecureRandom.uuid, fdom, 'bid', Time.new(2018, 10, 3))
+        add_limit_order(SecureRandom.uuid, oscar, 'bid', Time.new(2018, 10, 4))
+      end
+
+      it { expect(subject.orders.size).to eq(3) }
+      it 'sorts orders by date' do
+        expect(subject.bid_orders[0]['user_id']).to eq(fdom.id)
+        expect(subject.bid_orders[1]['user_id']).to eq(oscar.id)
+        expect(subject.bid_orders[2]['user_id']).to eq(andres.id)
+      end
+    end
+  end
+
   describe '#add_market_order' do
     context 'user with karma' do
       before do

--- a/spec/lita/services/market_manager_spec.rb
+++ b/spec/lita/services/market_manager_spec.rb
@@ -292,4 +292,21 @@ describe Lita::Services::MarketManager, lita: true do
       end
     end
   end
+
+  describe '#transaction_possible?' do
+    context 'transaction possible' do
+      it 'returns true' do
+        add_limit_order(SecureRandom.uuid, oscar, 'ask', Time.new(2018, 10, 5))
+        add_limit_order(SecureRandom.uuid, fdom, 'bid', Time.new(2018, 10, 3))
+        expect(subject.transaction_possible?).to be(true)
+      end
+    end
+
+    context 'transaction not possible' do
+      it 'returns nil' do
+        add_limit_order(SecureRandom.uuid, oscar, 'ask', Time.new(2018, 10, 5))
+        expect(subject.transaction_possible?).to be(nil)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Ahora se pueden crear bid orders sin que existan ask orders.

#### Market Manager:
- Se eliminó el método `add_market_order`.
- Se crea `transaction_possible?` que retorna `true` si es posible realizar una transacción
- Se crean métodos para obtener las `ask` y `bid` orders

#### Market API:
- Se eliminó el endpoint `place_market_order`
- Se adaptó el endpoint `place_limit_order`. Para simplificarlo se creó el método `add_limit_order`

#### Lunch Reminder:
- Se adaptó el código para funcionar sólo con limit orders
- Se crea el método `execute_transactions` para verificar si hay transacciones
- Al ingresar una order (`bid` o `ask`) se verifica si hay alguna transacción