### PR TITLE
Fix lunch market

### DIFF
--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -201,7 +201,7 @@ module Lita
         return unless order
         transaction = execute_transaction
         if transaction
-          notify_transaction(transaction[:buyer], transaction[:seller])
+          notify_transaction(transaction['buyer'], transaction['seller'])
         else
           response.reply_privately(
             "@#{user.mention_name}, #{t(:selling_lunch)}"
@@ -222,7 +222,7 @@ module Lita
         return unless order
         transaction = execute_transaction
         if transaction
-          notify_transaction(transaction[:buyer], transaction[:seller])
+          notify_transaction(transaction['buyer'], transaction['seller'])
         else
           response.reply_privately(
             "@#{user.mention_name}, #{t(:buying_lunch)}"
@@ -298,16 +298,16 @@ module Lita
       def execute_transaction
         executed_orders = @market.execute_transaction
         return unless executed_orders
-        ask_order = executed_orders[:ask]
-        bid_order = executed_orders[:bid]
+        ask_order = executed_orders['ask']
+        bid_order = executed_orders['bid']
         seller_user = Lita::User.find_by_id(ask_order['user_id'])
         buyer_user = Lita::User.find_by_id(bid_order['user_id'])
         {
-          buyer: buyer_user,
-          seller: seller_user,
-          timestamp: Time.now,
-          bid_order: bid_order,
-          ask_order: ask_order
+          'buyer' => buyer_user,
+          'seller' => seller_user,
+          'timestamp' => Time.now,
+          'bid_order' => bid_order,
+          'ask_order' => ask_order
         }
       end
 

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -300,8 +300,8 @@ module Lita
         return unless executed_orders
         ask_order = executed_orders[:ask]
         bid_order = executed_orders[:bid]
-        seller_user = Lita::User.find_by_id(ask_order[:user_id])
-        buyer_user = Lita::User.find_by_id(bid_order[:user_id])
+        seller_user = Lita::User.find_by_id(ask_order['user_id'])
+        buyer_user = Lita::User.find_by_id(bid_order['user_id'])
         {
           buyer: buyer_user,
           seller: seller_user,

--- a/lib/lita/services/market_manager.rb
+++ b/lib/lita/services/market_manager.rb
@@ -53,7 +53,7 @@ module Lita
         new_bid_orders[1..-1].each do |order|
           @redis.sadd('orders', order.to_json)
         end
-        { 'ask': new_ask_orders.first, 'bid': new_bid_orders.first }
+        { 'ask' => new_ask_orders.first, 'bid' => new_bid_orders.first }
       end
 
       def reset_limit_orders
@@ -63,8 +63,8 @@ module Lita
       def execute_transaction
         return unless transaction_possible?
         executed_orders = remove_orders
-        lunch_seller = Lita::User.find_by_id(executed_orders[:ask]['user_id'])
-        lunch_buyer = Lita::User.find_by_id(executed_orders[:bid]['user_id'])
+        lunch_seller = Lita::User.find_by_id(executed_orders['ask']['user_id'])
+        lunch_buyer = Lita::User.find_by_id(executed_orders['bid']['user_id'])
         @karmanager.transfer_karma(lunch_buyer.id, lunch_seller.id, 1)
         @lunch_assigner.transfer_lunch(lunch_seller.mention_name, lunch_buyer.mention_name)
         executed_orders

--- a/spec/lita/handlers/lunch_reminder_spec.rb
+++ b/spec/lita/handlers/lunch_reminder_spec.rb
@@ -78,14 +78,12 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
       end
 
       context 'one or more bid orders placed' do
-        let(:ask_order) { { 'id': 1111, 'user_id': 124, 'type': 'ask' } }
-        let(:bid_order) { { 'id': 2222, 'user_id': 123, 'type': 'bid' } }
+        let(:ask_order) { { 'id' => 1111, 'user_id' => 124, 'type' => 'ask' } }
+        let(:bid_order) { { 'id' => 2222, 'user_id' => 123, 'type' => 'bid' } }
         let(:orders) { { 'ask': ask_order, 'bid': bid_order } }
-
         let(:user) { double(mention_name: 'felipe.dominguez') }
         let(:lita_user) { Lita::User }
         let!(:user2) { Lita::User.create(124, mention_name: 'armando') }
-
         before do
           allow_any_instance_of(Lita::Services::MarketManager).to \
             receive(:execute_transaction).and_return(orders)
@@ -146,14 +144,12 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
       end
 
       context 'one or more ask orders placed' do
-        let(:ask_order) { { 'id': 1111, 'user_id': 123, 'type': 'ask' } }
-        let(:bid_order) { { 'id': 2222, 'user_id': 124, 'type': 'bid' } }
+        let(:ask_order) { { 'id' => 1111, 'user_id' => 123, 'type' => 'ask' } }
+        let(:bid_order) { { 'id' => 2222, 'user_id' => 124, 'type' => 'bid' } }
         let(:orders) { { 'ask': ask_order, 'bid': bid_order } }
-
         let(:user) { double(mention_name: 'felipe.dominguez') }
         let(:lita_user) { Lita::User }
         let!(:user2) { Lita::User.create(124, mention_name: 'armando') }
-
         before do
           allow_any_instance_of(Lita::Services::MarketManager).to \
             receive(:execute_transaction).and_return(orders)

--- a/spec/lita/handlers/lunch_reminder_spec.rb
+++ b/spec/lita/handlers/lunch_reminder_spec.rb
@@ -80,7 +80,7 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
       context 'one or more bid orders placed' do
         let(:ask_order) { { 'id' => 1111, 'user_id' => 124, 'type' => 'ask' } }
         let(:bid_order) { { 'id' => 2222, 'user_id' => 123, 'type' => 'bid' } }
-        let(:orders) { { 'ask': ask_order, 'bid': bid_order } }
+        let(:orders) { { 'ask' => ask_order, 'bid' => bid_order } }
         let(:user) { double(mention_name: 'felipe.dominguez') }
         let(:lita_user) { Lita::User }
         let!(:user2) { Lita::User.create(124, mention_name: 'armando') }
@@ -146,7 +146,7 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
       context 'one or more ask orders placed' do
         let(:ask_order) { { 'id' => 1111, 'user_id' => 123, 'type' => 'ask' } }
         let(:bid_order) { { 'id' => 2222, 'user_id' => 124, 'type' => 'bid' } }
-        let(:orders) { { 'ask': ask_order, 'bid': bid_order } }
+        let(:orders) { { 'ask' => ask_order, 'bid' => bid_order } }
         let(:user) { double(mention_name: 'felipe.dominguez') }
         let(:lita_user) { Lita::User }
         let!(:user2) { Lita::User.create(124, mention_name: 'armando') }

--- a/spec/lita/handlers/lunch_reminder_spec.rb
+++ b/spec/lita/handlers/lunch_reminder_spec.rb
@@ -78,8 +78,8 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
       end
 
       context 'one or more bid orders placed' do
-        let(:ask_order) { { 'id': 1111, 'user_id': 123, 'type': 'ask' } }
-        let(:bid_order) { { 'id': 2222, 'user_id': 124, 'type': 'bid' } }
+        let(:ask_order) { { 'id': 1111, 'user_id': 124, 'type': 'ask' } }
+        let(:bid_order) { { 'id': 2222, 'user_id': 123, 'type': 'bid' } }
         let(:orders) { { 'ask': ask_order, 'bid': bid_order } }
 
         let(:user) { double(mention_name: 'felipe.dominguez') }
@@ -97,15 +97,13 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
         it 'responds with transaction' do
           armando = Lita::User.create(124, mention_name: 'armando')
           send_message('@lita vendo almuerzo', as: armando)
-          expect(replies.last).to match('@armando le compró almuerzo a @felipe.dominguez')
+          expect(replies.last).to match('@felipe.dominguez le compró almuerzo a @armando')
         end
       end
     end
 
     context 'user without lunch' do
       before do
-        allow_any_instance_of(Lita::Services::MarketManager).to\
-          receive(:add_limit_order).and_return(true)
         allow_any_instance_of(Lita::Services::LunchAssigner).to\
           receive(:winning_lunchers_list).and_return([])
       end

--- a/spec/lita/services/market_manager_spec.rb
+++ b/spec/lita/services/market_manager_spec.rb
@@ -282,8 +282,8 @@ describe Lita::Services::MarketManager, lita: true do
 
       it 'matchs the correct limit order' do
         orders = subject.execute_transaction
-        expect(orders[:ask]['user_id']).to eq(andres.id)
-        expect(orders[:bid]['user_id']).to eq(fdom.id)
+        expect(orders['ask']['user_id']).to eq(andres.id)
+        expect(orders['bid']['user_id']).to eq(fdom.id)
       end
 
       it 'remove order from limit orders' do


### PR DESCRIPTION
Ham se caía porque en `execute_transaction`, accedía a los usuarios usando `symbols`. Ahora se accede todos los hashes usando `strings`.

Adapté también los test para que funcionen con el cambio.