### PR TITLE
fix(market): symbolize request params in place_limit_order

### DIFF
--- a/lib/lita/handlers/api/market.rb
+++ b/lib/lita/handlers/api/market.rb
@@ -24,7 +24,7 @@ module Lita
         def place_limit_order(request, response)
           return respond_not_authorized(response) unless authorized?(request)
           user = current_user(request)
-          type = request.params['type']
+          type = request.params[:type]
           limit_order = add_limit_order(user, type)
           if limit_order
             executed_orders = market_manager.execute_transaction

--- a/spec/lita/handlers/api/market_spec.rb
+++ b/spec/lita/handlers/api/market_spec.rb
@@ -102,6 +102,7 @@ describe Lita::Handlers::Api::Market, lita_handler: true do
 
         context 'no transaction possible' do
           before do
+            allow_any_instance_of(Rack::Request).to receive(:params).and_return(type: 'ask')
             allow(market).to \
               receive(:execute_transaction).and_return(nil)
           end
@@ -140,6 +141,7 @@ describe Lita::Handlers::Api::Market, lita_handler: true do
 
         context 'transaction possible' do
           before do
+            allow_any_instance_of(Rack::Request).to receive(:params).and_return(type: 'ask')
             allow(market).to \
               receive(:execute_transaction).and_return('ask': ask_order, 'bid': bid_order)
           end


### PR DESCRIPTION
Al hacer un `POST` a `market/limit_orders`, los parámetros se debían obtener usando symbols.