### PR TITLE
Emit karma

### DIFF
--- a/lib/lita-lunch-reminder.rb
+++ b/lib/lita-lunch-reminder.rb
@@ -17,6 +17,7 @@ require 'lita/services/weighted_picker'
 require 'lita/services/karmanager'
 require 'lita/services/market_manager'
 require 'lita/services/lunch_counter'
+require 'lita/services/karma_emitter'
 
 Lita::Handlers::LunchReminder.template_root File.expand_path(
   File.join('..', '..', 'templates'), __FILE__

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -5,6 +5,7 @@ module Lita
     class LunchReminder < Handler
       MAX_LUNCHERS = ENV.fetch('MAX_LUNCHERS').to_i
       MIN_LUNCHERS = MAX_LUNCHERS - 4
+      EMISSION_INTERVAL_DAYS = ENV.fetch('EMISSION_INTERVAL_DAYS', 30)
 
       on :loaded, :load_on_start
 
@@ -252,7 +253,7 @@ module Lita
 
       route(/reparte tu karma/i, command: true) do |response|
         days_since = (Date.today - @emitter.last_emission_date).to_i
-        if days_since > 30
+        if days_since > EMISSION_INTERVAL_DAYS
           users = @assigner.lunchers_list.map do |mention_name|
             Lita::User.find_by_mention_name(mention_name)
           end
@@ -260,7 +261,7 @@ module Lita
           response.reply(t(:karma_emitted, karma_amount: emitted_karma))
           broadcast_to_channel(t(:karma_emitted, karma_amount: emitted_karma), '#cooking')
         else
-          response.reply(t(:karma_not_emitted, days_remaining: 30 - days_since))
+          response.reply(t(:karma_not_emitted, days_remaining: EMISSION_INTERVAL_DAYS - days_since))
         end
       end
 

--- a/lib/lita/services/karma_emitter.rb
+++ b/lib/lita/services/karma_emitter.rb
@@ -1,0 +1,43 @@
+require 'redis'
+module Lita
+  module Services
+    class KarmaEmitter
+      attr_accessor :redis
+
+      KARMA_LIMIT = 50
+
+      def initialize(redis_instance, karmanager_instance)
+        @redis = redis_instance
+        @karmanager = karmanager_instance
+        @ham = Lita::User.find_by_mention_name('ham')
+      end
+
+      def emit(users, acc = 0)
+        users = users.select { |user| @karmanager.get_karma(user.id) < KARMA_LIMIT }
+        total_karma = @karmanager.get_karma(@ham.id)
+        karma_per_user = total_karma / users.size
+        return acc if karma_per_user == 0
+        users.each do |user|
+          acc += karma_to_emit(user, karma_per_user)
+          @karmanager.transfer_karma(
+            @ham.id,
+            user.id,
+            karma_to_emit(user, karma_per_user),
+            check_limit: false
+          )
+        end
+        emit(users, acc)
+      end
+
+      private
+
+      def karma_to_emit(user, karma_per_user)
+        karma_to_emit = karma_per_user
+        if @karmanager.get_karma(user.id) + karma_per_user > KARMA_LIMIT
+          karma_to_emit = KARMA_LIMIT - @karmanager.get_karma(user.id)
+        end
+        karma_to_emit
+      end
+    end
+  end
+end

--- a/lib/lita/services/karma_emitter.rb
+++ b/lib/lita/services/karma_emitter.rb
@@ -4,7 +4,7 @@ module Lita
     class KarmaEmitter
       attr_accessor :redis
 
-      KARMA_LIMIT = 50
+      KARMA_LIMIT = ENV.fetch('KARMA_LIMIT', 50)
 
       def initialize(redis_instance, karmanager_instance)
         @redis = redis_instance

--- a/lib/lita/services/karmanager.rb
+++ b/lib/lita/services/karmanager.rb
@@ -36,8 +36,8 @@ module Lita
         @redis.set("#{user_id}:karma_transfered", karma_transfered + amount)
       end
 
-      def transfer_karma(giver_id, receiver_id, amount)
-        return false unless can_transfer?(giver_id, amount)
+      def transfer_karma(giver_id, receiver_id, amount, options = { check_limit: true })
+        return false unless !options[:check_limit] || can_transfer?(giver_id, amount)
         decrease_karma_by(giver_id, amount)
         increase_karma_by(receiver_id, amount)
         true

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -14,6 +14,8 @@ en:
         mid_wagger: "Las apuestas fueron: %{waggers}"
         high_wagger: "Wow! Las apuestas fueron: %{waggers}"
         crazy_wagger: "La volaiiita... Las apuestas fueron: %{waggers}"
+        karma_emitted: "Repartí %{karma_amount} karmas entre todos. Recuerda: el que guarda siempre tiene"
+        karma_not_emitted: "No pude repartir el karma. Faltan %{days_remaining} días para que pueda emitir de nuevo"
         thanks_for_answering: "Ok! Gracias por avisar. Suerte!"
         no_one_lunches: "Hasta el momento.. no hay nadie que almuerce aquí hoy!"
         only_one_lunches: "Aparte de %{subject}, nadie más ha dicho que almuerza en la oficina..."

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -14,6 +14,8 @@ en:
         mid_wagger: "Las apuestas fueron: %{waggers}"
         high_wagger: "Wow! Las apuestas fueron: %{waggers}"
         crazy_wagger: "La volaiiita... Las apuestas fueron: %{waggers}"
+        karma_emitted: "Repartí %{karma_amount} karmas entre todos. Recuerda: el que guarda siempre tiene"
+        karma_not_emitted: "No pude repartir el karma. Faltan %{days_remaining} días para que pueda emitir de nuevo"
         thanks_for_answering: "Ok! Gracias por avisar. Suerte!"
         no_one_lunches: "Hasta el momento.. no hay nadie que almuerce aquí hoy!"
         only_one_lunches: "Aparte de %{subject}, nadie más ha dicho que almuerza en la oficina..."

--- a/spec/lita/handlers/lunch_reminder_spec.rb
+++ b/spec/lita/handlers/lunch_reminder_spec.rb
@@ -216,7 +216,9 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
 
       it 'does emit karma' do
         send_message('@lita reparte tu karma', as: andres)
-        expect(replies.last).to match("Repartí 10 karmas entre todos. Recuerda: el que guarda siempre tiene")
+        expect(replies.last).to(
+          match('Repartí 10 karmas entre todos. Recuerda: el que guarda siempre tiene')
+        )
       end
     end
 
@@ -226,7 +228,9 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
       it 'does not emit karma' do
         send_message('@lita reparte tu karma', as: andres)
         send_message('@lita reparte tu karma', as: andres)
-        expect(replies.last).to match("No pude repartir el karma. Faltan 30 días para que pueda emitir de nuevo")
+        expect(replies.last).to(
+          match('No pude repartir el karma. Faltan 30 días para que pueda emitir de nuevo')
+        )
       end
     end
   end

--- a/spec/lita/services/karma_emitter_spec.rb
+++ b/spec/lita/services/karma_emitter_spec.rb
@@ -31,6 +31,13 @@ describe Lita::Services::KarmaEmitter, lita: true do
       karmanager.set_karma(andres.id, andres_karma)
     end
 
+    it { expect(subject.last_emission_date).to eq(Date.parse('2000-01-01')) }
+
+    it 'changed the emission date to today' do
+      subject.emit(users)
+      expect(subject.last_emission_date).to eq(Date.today)
+    end
+
     context 'with ham having zero karma' do
       let(:ham_karma) { 0 }
 

--- a/spec/lita/services/karma_emitter_spec.rb
+++ b/spec/lita/services/karma_emitter_spec.rb
@@ -1,0 +1,162 @@
+require "spec_helper"
+require 'pry'
+require 'dotenv/load'
+
+describe Lita::Services::KarmaEmitter, lita: true do
+  let(:robot) { Lita::Robot.new(registry) }
+  let(:lunch_reminder) { Lita::Handlers::LunchReminder.new(robot) }
+  let(:karmanager) { Lita::Services::Karmanager.new(lunch_reminder.redis) }
+  let(:subject) { described_class.new(lunch_reminder.redis, karmanager) }
+  let(:ham) { Lita::User.create(126, mention_name: "ham") }
+  let(:andres) { Lita::User.create(127, mention_name: "andres") }
+  let(:cristobal) { Lita::User.create(128, mention_name: "cristobal") }
+  let(:jaime) { Lita::User.create(129, mention_name: "jaime") }
+  let(:ham_karma) { 1 }
+  let(:andres_karma) { 2 }
+  let(:cristobal_karma) { 10 }
+  let(:jaime_karma) { 20 }
+  let(:users) { [andres, cristobal, jaime] }
+
+  before do
+    karmanager.set_karma(ham.id, ham_karma)
+    karmanager.set_karma(andres.id, andres_karma)
+    karmanager.set_karma(cristobal.id, cristobal_karma)
+    karmanager.set_karma(jaime.id, jaime_karma)
+  end
+
+  context 'with one user' do
+    let(:users) { [andres] }
+
+    before do
+      karmanager.set_karma(andres.id, andres_karma)
+    end
+
+    context 'with ham having zero karma' do
+      let(:ham_karma) { 0 }
+
+      it 'does not transfer karma from ham to a user' do
+        subject.emit(users)
+        expect(karmanager.get_karma(ham.id)).to eq(0)
+        expect(karmanager.get_karma(andres.id)).to eq(2)
+      end
+
+      it { expect(subject.emit(users)).to eq(0) }
+    end
+
+    context 'with ham having one karma' do
+      let(:ham_karma) { 1 }
+
+      it 'transfers one karma from ham to a user' do
+        subject.emit(users)
+        expect(karmanager.get_karma(ham.id)).to eq(0)
+        expect(karmanager.get_karma(andres.id)).to eq(3)
+      end
+
+      it { expect(subject.emit(users)).to eq(1) }
+    end
+
+    context 'with ham having more than one karma' do
+      let(:ham_karma) { 10 }
+
+      it 'transfers one karma from ham to a user' do
+        subject.emit(users)
+        expect(karmanager.get_karma(ham.id)).to eq(0)
+        expect(karmanager.get_karma(andres.id)).to eq(12)
+      end
+
+      it { expect(subject.emit(users)).to eq(10) }
+    end
+  end
+
+  context 'with more than one user' do
+    let(:users) { [andres, cristobal, jaime] }
+
+    context 'with ham having less karma than the number of users' do
+      let(:ham_karma) { 2 }
+      let(:andres_karma) { 10 }
+      let(:cristobal_karma) { 10 }
+      let(:jaime_karma) { 10 }
+
+      it 'does not transfer karma from ham to any user' do
+        subject.emit(users)
+        users_karma = users.map { |user| karmanager.get_karma(user.id) }
+        expect(karmanager.get_karma(ham.id)).to eq(2)
+        expect(users_karma.uniq).to eq([10])
+      end
+
+      it { expect(subject.emit(users)).to eq(0) }
+    end
+
+    context 'with ham having as karma a number divisible by the number of users' do
+      let(:ham_karma) { 30 }
+      let(:andres_karma) { 10 }
+      let(:cristobal_karma) { 10 }
+      let(:jaime_karma) { 10 }
+
+      it 'does not transfer karma from ham to any user' do
+        subject.emit(users)
+        users_karma = users.map { |user| karmanager.get_karma(user.id) }
+        expect(karmanager.get_karma(ham.id)).to eq(0)
+        expect(users_karma.uniq).to eq([20])
+      end
+
+      it { expect(subject.emit(users)).to eq(30) }
+    end
+
+    context 'with ham having as karma a number not divisible by the number of users' do
+      let(:ham_karma) { 32 }
+      let(:andres_karma) { 10 }
+      let(:cristobal_karma) { 10 }
+      let(:jaime_karma) { 10 }
+
+      it 'does not transfer karma from ham to any user' do
+        subject.emit(users)
+        users_karma = users.map { |user| karmanager.get_karma(user.id) }
+        expect(karmanager.get_karma(ham.id)).to eq(2)
+        expect(users_karma.uniq).to eq([20])
+      end
+
+      it { expect(subject.emit(users)).to eq(30) }
+    end
+
+    context 'with one user having the maximum karma' do
+      let(:ham_karma) { 30 }
+      let(:andres_karma) { 10 }
+      let(:cristobal_karma) { 10 }
+      let(:jaime_karma) { 50 }
+
+      it 'does not transfer karma to user in limit' do
+        subject.emit(users)
+        expect(karmanager.get_karma(jaime.id)).to eq(50)
+      end
+
+      it 'transfers karma to users not in limit' do
+        subject.emit(users)
+        expect(karmanager.get_karma(andres.id)).to eq(25)
+        expect(karmanager.get_karma(cristobal.id)).to eq(25)
+      end
+
+      it { expect(subject.emit(users)).to eq(30) }
+    end
+
+    context 'with one user such that if the karma is emitted to him, he will have more than the max' do
+      let(:ham_karma) { 30 }
+      let(:andres_karma) { 10 }
+      let(:cristobal_karma) { 10 }
+      let(:jaime_karma) { 48 }
+
+      it 'emits only the remaining karma to reach the limit' do
+        subject.emit(users)
+        expect(karmanager.get_karma(jaime.id)).to eq(50)
+      end
+
+      it 'transfers the reminder to the other participants' do
+        subject.emit(users)
+        expect(karmanager.get_karma(andres.id)).to eq(24)
+        expect(karmanager.get_karma(cristobal.id)).to eq(24)
+      end
+
+      it { expect(subject.emit(users)).to eq(30) }
+    end
+  end
+end


### PR DESCRIPTION
Se implementa emisión/distribución de karma cada 30 días.

Reglas:

- Se divide el karma que tiene ham por el número de usuarios, y se reparte en partes iguales para todos. La división es entera, y lo que sobra se lo queda ham.
- Hay un límite a la riqueza, si alguien tiene más karma que eso no se le da karma.
- Si alguien tiene N y la faltan D para llegar al límite, se le da el mínimo entre D y lo que le corresponde en la repartija.

