### PR TITLE
Feat/add user to channel

### DIFF
--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -266,7 +266,7 @@ module Lita
         end
       end
 
-      route(/quiero pedir/i, command: true) do |response|
+      route(/quiero pedir/i, command: true, help: help_msg(:want_delivery)) do |response|
         mention_msg = mention_in_thread(response.user.mention_name, get_winners_msg_ts)
         response.reply(t(:food_delivery_link,
           channel_code: mention_msg['channel'], ts: mention_msg['ts'].remove('.')))

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -337,6 +337,15 @@ module Lita
         notify(@assigner.loosing_lunchers_list, t(:current_lunchers_too_many))
       end
 
+      def mention_in_thread(user, thread_ts)
+        @slack_client.chat_postMessage(
+          channel: 'cooking-dev',
+          text: "<@#{user}>",
+          thread_ts: thread_ts,
+          as_user: true
+        )
+      end
+
       def create_schedule
         scheduler = Rufus::Scheduler.new
         scheduler.cron(ENV['ASK_CRON']) do

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -15,6 +15,7 @@ module Lita
         @assigner = Lita::Services::LunchAssigner.new(redis, @karmanager)
         @emitter = Lita::Services::KarmaEmitter.new(redis, @karmanager)
         @market = Lita::Services::MarketManager.new(redis, @assigner, @karmanager)
+        @slack_client = Slack::Web::Client.new
       end
 
       def self.help_msg(route)

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -267,9 +267,9 @@ module Lita
       end
 
       route(/quiero pedir/i, command: true, help: help_msg(:want_delivery)) do |response|
-        mention_msg = mention_in_thread(response.user.mention_name, get_winners_msg_ts)
+        mention_msg = mention_in_thread(response.user.mention_name, get_winners_msg_timestamp)
         response.reply(t(:food_delivery_link,
-          channel_code: mention_msg['channel'], ts: mention_msg['ts'].remove('.')))
+          channel_code: mention_msg['channel'], timestamp: mention_msg['ts'].remove('.')))
       end
 
       def add_user_to_lunchers(mention_name)
@@ -339,23 +339,23 @@ module Lita
           '#cooking'
         )
         comment_in_thread(t(:food_delivery), winners_msg['ts'])
-        save_winners_msg_ts(winners_msg['ts'])
+        save_winners_msg_timestamp(winners_msg['ts'])
         waggers = @assigner.wager_hash(@assigner.winning_lunchers_list).values.sort.reverse
         announce_waggers(waggers)
         notify(@assigner.loosing_lunchers_list, t(:current_lunchers_too_many))
       end
 
-      def comment_in_thread(msg, thread_ts)
+      def comment_in_thread(msg, thread_timestamp)
         @slack_client.chat_postMessage(
           channel: 'cooking',
           text: msg,
-          thread_ts: thread_ts,
+          thread_ts: thread_timestamp,
           as_user: true
         )
       end
 
-      def mention_in_thread(user, thread_ts)
-        comment_in_thread("<@#{user}>", thread_ts)
+      def mention_in_thread(user, thread_timestamp)
+        comment_in_thread("<@#{user}>", thread_timestamp)
       end
 
       def create_schedule
@@ -431,12 +431,12 @@ module Lita
         robot.send_message(Source.new(user: user), message) if user
       end
 
-      def save_winners_msg_ts(ts)
-        redis.set('winners_msg_ts', ts)
+      def save_winners_msg_timestamp(timestamp)
+        redis.set('winners_msg_timestamp', timestamp)
       end
 
-      def get_winners_msg_ts
-        redis.get('winners_msg_ts')
+      def get_winners_msg_timestamp
+        redis.get('winners_msg_timestamp')
       end
 
       Lita.register_handler(self)

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -267,7 +267,9 @@ module Lita
       end
 
       route(/quiero pedir/i, command: true) do |response|
-        mention_in_thread(response.user.mention_name, get_winners_msg_ts)
+        mention_msg = mention_in_thread(response.user.mention_name, get_winners_msg_ts)
+        response.reply(t(:food_delivery_link,
+          channel_code: mention_msg['channel'], ts: mention_msg['ts'].remove('.')))
       end
 
       def add_user_to_lunchers(mention_name)
@@ -353,7 +355,7 @@ module Lita
       end
 
       def mention_in_thread(user, thread_ts)
-        comment_in_thread('<@#{user}>', thread_ts)
+        comment_in_thread("<@#{user}>", thread_ts)
       end
 
       def create_schedule

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -336,19 +336,24 @@ module Lita
             subject2: @assigner.winning_lunchers_list.shuffle.join(', ')),
           '#cooking'
         )
+        comment_in_thread(t(:food_delivery), winners_msg['ts'])
         save_winners_msg_ts(winners_msg['ts'])
         waggers = @assigner.wager_hash(@assigner.winning_lunchers_list).values.sort.reverse
         announce_waggers(waggers)
         notify(@assigner.loosing_lunchers_list, t(:current_lunchers_too_many))
       end
 
-      def mention_in_thread(user, thread_ts)
+      def comment_in_thread(msg, thread_ts)
         @slack_client.chat_postMessage(
           channel: 'cooking-dev',
-          text: "<@#{user}>",
+          text: msg,
           thread_ts: thread_ts,
           as_user: true
         )
+      end
+
+      def mention_in_thread(user, thread_ts)
+        comment_in_thread('<@#{user}>', thread_ts)
       end
 
       def create_schedule

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -347,7 +347,7 @@ module Lita
 
       def comment_in_thread(msg, thread_ts)
         @slack_client.chat_postMessage(
-          channel: 'cooking-dev',
+          channel: 'cooking',
           text: msg,
           thread_ts: thread_ts,
           as_user: true
@@ -434,7 +434,7 @@ module Lita
       def save_winners_msg_ts(ts)
         redis.set('winners_msg_ts', ts)
       end
-  
+
       def get_winners_msg_ts
         redis.get('winners_msg_ts')
       end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -38,6 +38,7 @@ en:
         cant_buy: 'no te puedo comprar almuerzo...'
         cant_sell: 'no puedes vender algo que no tienes!'
         announce_count: '%{subject1} la cuenta de almuerzos en %{month} fue: Platanus: %{count1}, Fintual: %{count2}, Buda: %{count3}'
+        food_delivery: 'Pizza? Subway? Mechada? Vean que quieren pedir!'
         help:
           thanks:
             usage: gracias

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -39,7 +39,7 @@ en:
         cant_sell: 'no puedes vender algo que no tienes!'
         announce_count: '%{subject1} la cuenta de almuerzos en %{month} fue: Platanus: %{count1}, Fintual: %{count2}, Buda: %{count3}'
         food_delivery: 'Pizza? Subway? Mechada? Vean que quieren pedir!'
-        food_delivery_link: 'Te incluí aquí https://platanus.slack.com/archives/%{channel_code}/p%{ts} para que veas que pedir con los demás hambrientos'
+        food_delivery_link: 'Te incluí aquí https://platanus.slack.com/archives/%{channel_code}/p%{timestamp} para que veas que pedir con los demás hambrientos'
         help:
           thanks:
             usage: gracias

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -9,7 +9,7 @@ en:
         already_considered_you: "No te preocupes @%{subject}, ya te tenía considerado para los almuerzos."
         current_lunchers_one: "Eres el primero en avisar que almuerza hoy, pero no te aseguro nada..."
         current_lunchers_some: "Hmm.. Ya van %{subject} que les gustaría almorzar aquí hoy."
-        current_lunchers_too_many: "Ups, saliste escogido, no cabes :("
+        current_lunchers_too_many: "Ups, saliste escogido, no cabes :(. Avísame si quieres pedir comida!"
         low_wagger: "¿Hay lentejas? ¿Feriado? Las apuestas fueron: %{waggers}"
         mid_wagger: "Las apuestas fueron: %{waggers}"
         high_wagger: "Wow! Las apuestas fueron: %{waggers}"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -39,6 +39,7 @@ en:
         cant_sell: 'no puedes vender algo que no tienes!'
         announce_count: '%{subject1} la cuenta de almuerzos en %{month} fue: Platanus: %{count1}, Fintual: %{count2}, Buda: %{count3}'
         food_delivery: 'Pizza? Subway? Mechada? Vean que quieren pedir!'
+        food_delivery_link: 'Te incluí aquí https://platanus.slack.com/archives/%{channel_code}/p%{ts} para que veas que pedir con los demás hambrientos'
         help:
           thanks:
             usage: gracias

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -84,5 +84,8 @@ en:
             usage: vende mi almuerzo
             description: Pon una orden de venta de almuerzo
           buy_lunch:
-            usage: vende mi almuerzo
+            usage: compro almuerzo
             description: Pon una orden de compra de almuerzo
+          want_delivery:
+            usage: quiero pedir
+            description: Incluirme en un thread para quienes quieren pedir delivery

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -38,6 +38,7 @@ en:
         cant_buy: 'no te puedo comprar almuerzo...'
         cant_sell: 'no puedes vender algo que no tienes!'
         announce_count: '%{subject1} la cuenta de almuerzos en %{month} fue: Platanus: %{count1}, Fintual: %{count2}, Buda: %{count3}'
+        food_delivery: 'Pizza? Subway? Mechada? Vean que quieren pedir!'
         help:
           thanks:
             usage: gracias

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -39,7 +39,7 @@ en:
         cant_sell: 'no puedes vender algo que no tienes!'
         announce_count: '%{subject1} la cuenta de almuerzos en %{month} fue: Platanus: %{count1}, Fintual: %{count2}, Buda: %{count3}'
         food_delivery: 'Pizza? Subway? Mechada? Vean que quieren pedir!'
-        food_delivery_link: 'Te incluí aquí https://platanus.slack.com/archives/%{channel_code}/p%{ts} para que veas que pedir con los demás hambrientos'
+        food_delivery_link: 'Te incluí aquí https://platanus.slack.com/archives/%{channel_code}/p%{timestamp} para que veas que pedir con los demás hambrientos'
         help:
           thanks:
             usage: gracias

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -9,7 +9,7 @@ en:
         already_considered_you: "No te preocupes @%{subject}, ya te tenía considerado para los almuerzos."
         current_lunchers_one: "Eres el primero en avisar que almuerza hoy, pero no te aseguro nada..."
         current_lunchers_some: "Hmm.. Ya van %{subject} que les gustaría almorzar aquí hoy."
-        current_lunchers_too_many: "Ups, saliste escogido, no cabes :("
+        current_lunchers_too_many: "Ups, saliste escogido, no cabes :(. Avísame si quieres pedir comida!"
         low_wagger: "¿Hay lentejas? ¿Feriado? Las apuestas fueron: %{waggers}"
         mid_wagger: "Las apuestas fueron: %{waggers}"
         high_wagger: "Wow! Las apuestas fueron: %{waggers}"

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -39,6 +39,7 @@ en:
         cant_sell: 'no puedes vender algo que no tienes!'
         announce_count: '%{subject1} la cuenta de almuerzos en %{month} fue: Platanus: %{count1}, Fintual: %{count2}, Buda: %{count3}'
         food_delivery: 'Pizza? Subway? Mechada? Vean que quieren pedir!'
+        food_delivery_link: 'Te incluí aquí https://platanus.slack.com/archives/%{channel_code}/p%{ts} para que veas que pedir con los demás hambrientos'
         help:
           thanks:
             usage: gracias

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -84,5 +84,8 @@ en:
             usage: vende mi almuerzo
             description: Pon una orden de venta de almuerzo
           buy_lunch:
-            usage: vende mi almuerzo
+            usage: compro almuerzo
             description: Pon una orden de compra de almuerzo
+          want_delivery:
+            usage: quiero pedir
+            description: Incluirme en un thread para quienes quieren pedir delivery


### PR DESCRIPTION
Se agrega una funcionalidad para facilitar la organización entre las personas que quieran pedir delivery

### Cambios
- Se inicializa cliente de slack (agregado anteriormente en ham). Este se usa para agregar la funcionalidad de comentar en un thread (con lita y lita-slack no se puede directamente)
- Se agrega ruta `quiero pedir`. Esta te menciona en un thread en #cooking donde los que quieran pedir pueden organizarse. Además, te manda por interno un link a ese thread para que puedas verlo fácilmente
- Se agrega al mensaje que se manda a los que no quedan con ham para incitarlos a avisar si quieren pedir comida
- Se agrega mensaje de ayuda para el nuevo comando y se arregla uno antiguo

![jan-18-2019 16-00-20](https://user-images.githubusercontent.com/12057523/51407296-3ef7ef80-1b3a-11e9-82bc-0062bb264878.gif)
