### PR TITLE
Cancel orders

### DIFF
--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -202,7 +202,7 @@ module Lita
         end
       end
 
-      route(/vend[oe] (mi|\s)? ?almuerzo/i,
+      route(/^vend[oe] (mi|\s)? ?almuerzo/i,
         command: true, help: help_msg(:sell_lunch)) do |response|
         user = response.user
         new_order = create_order(user, 'ask')
@@ -255,7 +255,7 @@ module Lita
         )
       end
 
-      route(/c(o|ó)mpr(o|ame|a)? (un )?almuerzo/i,
+      route(/^c(o|ó)mpr(o|ame|a)? (un )?almuerzo/i,
         command: true, help: help_msg(:buy_lunch)) do |response|
         user = response.user
         new_order = create_order(user, 'bid')

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -224,7 +224,7 @@ module Lita
       end
 
       route(/ya no (me )?vend(o|as)( (mi )?almuerzo)?/i,
-        command: true) do |response|
+        command: true, help: help_msg(:cancel_lunch_sell_order)) do |response|
         user = response.user
         order = @market.find_order('ask', user.id)
         if order.nil?
@@ -240,7 +240,7 @@ module Lita
       end
 
       route(/ya no (me )?compr(o|es)( (un )?almuerzo)?/i,
-        command: true) do |response|
+        command: true, help: help_msg(:cancel_lunch_buy_order)) do |response|
         user = response.user
         order = @market.find_order('bid', user.id)
         if order.nil?

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -211,7 +211,7 @@ module Lita
           next
         end
         order = @market.add_limit_order(new_order)
-        return unless order
+        next unless order
         transaction = execute_transaction
         if transaction
           notify_transaction(transaction['buyer'], transaction['seller'])
@@ -264,7 +264,7 @@ module Lita
           next
         end
         order = @market.add_limit_order(new_order)
-        return unless order
+        next unless order
         transaction = execute_transaction
         if transaction
           notify_transaction(transaction['buyer'], transaction['seller'])

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -223,6 +223,38 @@ module Lita
         end
       end
 
+      route(/ya no (me )?vend(o|as)( (mi )?almuerzo)?/i,
+        command: true) do |response|
+        user = response.user
+        order = @market.find_order('ask', user.id)
+        if order.nil?
+          response.reply(t(:not_selling_lunch))
+          next
+        end
+        @market.remove_order(order)
+        response.reply_privately("@#{user.mention_name}, #{t(:selling_lunch_cancelled)}")
+        broadcast_to_channel(
+          "@#{user.mention_name}, #{t(:selling_lunch_cancelled)}",
+          COOKING_CHANNEL
+        )
+      end
+
+      route(/ya no (me )?compr(o|es)( (un )?almuerzo)?/i,
+        command: true) do |response|
+        user = response.user
+        order = @market.find_order('bid', user.id)
+        if order.nil?
+          response.reply(t(:not_buying_lunch))
+          next
+        end
+        @market.remove_order(order)
+        response.reply_privately("@#{user.mention_name}, #{t(:buying_lunch_cancelled)}")
+        broadcast_to_channel(
+          "@#{user.mention_name}, #{t(:buying_lunch_cancelled)}",
+          COOKING_CHANNEL
+        )
+      end
+
       route(/c(o|ó)mpr(o|ame|a)? (un )?almuerzo/i,
         command: true, help: help_msg(:buy_lunch)) do |response|
         user = response.user

--- a/lib/lita/services/market_manager.rb
+++ b/lib/lita/services/market_manager.rb
@@ -33,6 +33,14 @@ module Lita
               .sort { |x, y| Time.parse(x['created_at']) <=> Time.parse(y['created_at']) }
       end
 
+      def find_order(type, user_id)
+        orders.find { |order| order['type'] == type && order['user_id'] == user_id }
+      end
+
+      def remove_order(order)
+        @redis.srem('orders', order.to_json)
+      end
+
       def add_limit_order(new_order)
         return if placed_limit_order?(JSON.parse(new_order)['user_id'])
         @redis.sadd('orders', new_order)

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -93,3 +93,9 @@ en:
           want_delivery:
             usage: quiero pedir
             description: Incluirme en un thread para quienes quieren pedir delivery
+          cancel_lunch_sell_order:
+            usage: ya no vendo
+            description: Cancelar tu orden de venta de almuerzo
+          cancel_lunch_buy_order:
+            usage: ya no compro
+            description: Cancelar tu orden de compra de almuerzo

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -31,7 +31,11 @@ en:
         dinner_is_served: "Está listo amiguito, *suba* a almorzar ;)"
         friend_added: "Perfecto @%{subject}, anoté a tu invitado como invitado_de_%{subject}."
         selling_lunch: 'tengo tu almuerzo en venta!'
+        selling_lunch_cancelled: 'ya no venderé tu almuerzo'
+        not_selling_lunch: 'Nunca estuviste vendiendo :unamused:'
         buying_lunch: 'voy a tratar de conseguirte almuerzo!'
+        buying_lunch_cancelled: 'ya no te conseguiré almuerzo'
+        not_buying_lunch: 'Nunca estuviste comprando :unamused:'
         bought_lunch: 'ya te conseguí almuerzo!'
         sold_lunch: 'ya te vendí almuerzo!'
         transaction: "@%{subject1} le compró almuerzo a @%{subject2}"


### PR DESCRIPTION
Este PR permite eliminar órdenes de compra y venta de almuerzos. Se agregan los métodos necesarios a `market_manager` y los respectivos mensajes de ayuda

Se aprovecha de arreglar un bug en dos endpoints: había `return`s en vez de `next`s. Esto no era grave porque el mono seguía corriendo pero la ejecución de dicha `route` se cortaba y se levantaba una excepción que quedaba loggeada.