### PR TITLE
Karma list

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The following environment variables should be defined in your Lita instance:
 - WAIT_RESPONSES_SECONDS
 - PERSIST_CRON
 - COUNTS_CRON
+- KARMA_LIST_CRON
 - LUNCH_ADMIN
 - KARMA_LIMIT: max karma users can have - default: 50
 - MAIN_SHEET

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -278,6 +278,19 @@ module Lita
           channel_code: mention_msg['channel'], timestamp: mention_msg['ts'].remove('.')))
       end
 
+      route(/(show me the money)|(mu(e|é)stra(me)? la lista( de karma)?)/i,
+        command: true, help: help_msg(:want_delivery)) do |response|
+        response.reply_privately(karma_list_message)
+      end
+
+      def karma_list_message
+        karma_list = @karmanager.karma_list(@assigner.lunchers_list)
+        entries = karma_list.map do |mention_name, karma|
+          t(:karma_list_entry, mention_name: mention_name, karma: karma)
+        end.join("\n")
+        t(:karma_list, entries: entries)
+      end
+
       def add_user_to_lunchers(mention_name)
         @assigner.add_to_current_lunchers(mention_name)
         @assigner.add_to_winning_lunchers(mention_name) if @assigner.already_assigned?

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -391,6 +391,10 @@ module Lita
         notify(@assigner.loosing_lunchers_list, t(:current_lunchers_too_many))
       end
 
+      def announce_karma_list
+        broadcast_to_channel(karma_list_message, KARMA_AUDIT_CHANNEL)
+      end
+
       def comment_in_thread(msg, thread_timestamp)
         @slack_client.chat_postMessage(
           channel: COOKING_CHANNEL.delete('#'),
@@ -404,7 +408,7 @@ module Lita
         comment_in_thread("<@#{user}>", thread_timestamp)
       end
 
-      def create_schedule
+      def create_schedule # rubocop:disable Metric/MethodLength
         scheduler = Rufus::Scheduler.new
         scheduler.cron(ENV['ASK_CRON']) do
           refresh
@@ -418,6 +422,9 @@ module Lita
         end
         scheduler.cron(ENV.fetch('COUNTS_CRON')) do
           count_lunches
+        end
+        scheduler.cron(ENV.fetch('KARMA_LIST_CRON')) do
+          announce_karma_list
         end
       end
 

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -279,7 +279,7 @@ module Lita
       end
 
       route(/(show me the money)|(mu(e|é)stra(me)? la lista( de karma)?)/i,
-        command: true, help: help_msg(:want_delivery)) do |response|
+        command: true, help: help_msg(:karma_list)) do |response|
         response.reply_privately(karma_list_message)
       end
 

--- a/lib/lita/services/karmanager.rb
+++ b/lib/lita/services/karmanager.rb
@@ -87,6 +87,14 @@ module Lita
         end
         total_karma / list.length
       end
+
+      def karma_list(lunchers_list)
+        lunchers_list.map do |m|
+          usr = Lita::User.find_by_mention_name(m)
+          raise Exception.new("Can't find mention name '#{m}'") if !usr
+          [m, get_karma(usr.id)]
+        end
+      end
     end
   end
 end

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -44,6 +44,8 @@ en:
         announce_count: '%{subject1} la cuenta de almuerzos en %{month} fue: Platanus: %{count1}, Fintual: %{count2}, Buda: %{count3}'
         food_delivery: 'Pizza? Subway? Mechada? Vean que quieren pedir!'
         food_delivery_link: 'Te incluí aquí https://platanus.slack.com/archives/%{channel_code}/p%{timestamp} para que veas que pedir con los demás hambrientos'
+        karma_list_entry: '@%{mention_name} tiene %{karma}'
+        karma_list: ":frog: aquí va la lista de :karma::\n%{entries}"
         help:
           thanks:
             usage: gracias

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -101,3 +101,6 @@ en:
           cancel_lunch_buy_order:
             usage: ya no compro
             description: Cancelar tu orden de compra de almuerzo
+          karma_list:
+            usage: show me the money
+            description: Pedir listado de karma de todos los almorzadores


### PR DESCRIPTION
Este PR agrega la posibilidad de sapear la lista de los karmas de todos los almorzadores. Agrega el comando `show me the money` (con el equivalente `muestrame la lista de karma`) para esto, pero responde privadamente por lo largo del mensaje. Agrega la posibilidad de que se postee en el canal de audit segun la variable de entorno `KARMA_LIST_CRON`.