### PR TITLE
Specs fix

### DIFF
--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -194,7 +194,9 @@ module Lita
       end
 
       route(/.*/i, command: false) do |response|
-        if quiet_time? && Lita::Room.find_by_name('lita-test').id == response.room.id
+        silenced_room = Lita::Room.find_by_name('lita-test')
+        next unless silenced_room && response.room
+        if quiet_time? && silenced_room.id == response.room.id
           user = Lita::User.find_by_mention_name('agustin')
           message = 'Estoy empezando a sugerir que evitemos hablar en #coffeebar entre las 10 y' \
           'las 12 del día para que la gente en la oficina pueda concentrarse. Las interrupciones' \

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+require 'slack-ruby-client'
+
 module Lita
   module Handlers
     class LunchReminder < Handler

--- a/lita-lunch-reminder.gemspec
+++ b/lita-lunch-reminder.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "lita", ">= 4.7"
   spec.add_runtime_dependency "google_drive"
   spec.add_runtime_dependency "rufus-scheduler"
+  spec.add_runtime_dependency "slack-ruby-client"
+  spec.add_runtime_dependency "json", "1.8.6"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "pry-byebug"


### PR DESCRIPTION
Este PR arregla parcialmente los test. Para eso:

- Explícitamente requiere a `ruby-slack-client` en el handler.
- Modifica una de las rutas para que no falle en los specs (en producción funciona bien porque encuentra el `room` pero en specs no).
- Se agrega `json` 1.8.6 al `gemspec` porque por alguna razón que no logré identificar por completo al parecer al hacer bundle install en la gema, no considera los requerimientos "anidados".

Es parcial porque hay otros tests que no tienen que ver con lunch-reminder que no están correctos, y se agregaron las tarjetas respectivas a Trello.

\***Nota**: Por alguna razón solo logré correr los tests con ruby 2.5. Decidí no agregar un `.ruby-version` al proyecto porque no es la práctica usual en los plugins de lita.