### PR TITLE
Free market

### DIFF
--- a/lib/lita-lunch-reminder.rb
+++ b/lib/lita-lunch-reminder.rb
@@ -1,3 +1,4 @@
+
 require 'lita'
 require 'redis'
 require 'rufus-scheduler'
@@ -5,6 +6,11 @@ require 'rufus-scheduler'
 Lita.load_locales Dir[File.expand_path(
   File.join('..', '..', 'locales', '*.yml'), __FILE__
 )]
+
+if ENV['RACK_ENV'] != 'production'
+  require 'dotenv'
+  Dotenv.load('.env')
+end
 
 require 'lita/handlers/lunch_reminder'
 require 'lita/handlers/api/api_controller'

--- a/lib/lita/handlers/api/market.rb
+++ b/lib/lita/handlers/api/market.rb
@@ -44,19 +44,10 @@ module Lita
         private
 
         def add_limit_order(user, type)
-          order = limit_order_for_user(user, type)
           has_lunch = winning_list.include?(user.mention_name)
           return unless (has_lunch && type == 'ask') || (!has_lunch && type == 'bid')
-          return order if market_manager.add_limit_order(order)
-        end
 
-        def limit_order_for_user(user, type)
-          {
-            id: SecureRandom.uuid,
-            user_id: user.id,
-            type: type,
-            created_at: Time.now
-          }.to_json
+          market_manager.add_limit_order(user: user, type: type)
         end
 
         def winning_list

--- a/lib/lita/handlers/api/market.rb
+++ b/lib/lita/handlers/api/market.rb
@@ -27,9 +27,9 @@ module Lita
           type = request.params[:type]
           limit_order = add_limit_order(user, type)
           if limit_order
-            executed_orders = market_manager.execute_transaction
-            if executed_orders
-              respond(response, success: true, executed_orders: executed_orders.to_json)
+            executed_tx = market_manager.execute_transaction
+            if executed_tx
+              respond(response, success: true, executed_orders: executed_tx.to_json)
             else
               respond(response, success: true, order: limit_order)
             end

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -213,8 +213,7 @@ module Lita
           next
         end
         next unless @market.add_limit_order(user: user, type: 'ask')
-        transaction = execute_transaction
-        if transaction
+        if transaction = @market.execute_transaction
           notify_transaction(transaction['buyer'], transaction['seller'])
         else
           response.reply_privately(
@@ -242,8 +241,7 @@ module Lita
           next
         end
         next unless @market.add_limit_order(user: user, type: 'bid')
-        transaction = execute_transaction
-        if transaction
+        if transaction = @market.execute_transaction
           notify_transaction(transaction['buyer'], transaction['seller'])
         else
           response.reply_privately(
@@ -456,22 +454,6 @@ module Lita
 
       def winning_list
         @winning_list ||= @assigner.winning_lunchers_list
-      end
-
-      def execute_transaction
-        executed_orders = @market.execute_transaction
-        return unless executed_orders
-        ask_order = executed_orders['ask']
-        bid_order = executed_orders['bid']
-        seller_user = Lita::User.find_by_id(ask_order['user_id'])
-        buyer_user = Lita::User.find_by_id(bid_order['user_id'])
-        {
-          'buyer' => buyer_user,
-          'seller' => seller_user,
-          'timestamp' => Time.now,
-          'bid_order' => bid_order,
-          'ask_order' => ask_order
-        }
       end
 
       def notify_transaction(buyer_user, seller_user)

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -213,7 +213,7 @@ module Lita
           response.reply("@#{user.mention_name} #{t(:cant_sell)}")
           next
         end
-        next unless @market.add_limit_order(user: user, type: 'ask')
+        next unless @market.add_limit_order(user: user, type: 'ask', price: price)
         if transaction = @market.execute_transaction
           notify_transaction(transaction['buyer'], transaction['seller'], price)
         else
@@ -245,7 +245,7 @@ module Lita
           response.reply("@#{user.mention_name} #{t(:cant_buy)}")
           next
         end
-        next unless @market.add_limit_order(user: user, type: 'bid')
+        next unless @market.add_limit_order(user: user, type: 'bid', price: price)
         if transaction = @market.execute_transaction
           notify_transaction(transaction['buyer'], transaction['seller'], price)
         else

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -215,7 +215,7 @@ module Lita
         end
         next unless @market.add_limit_order(user: user, type: 'ask', price: price)
         if transaction = @market.execute_transaction
-          notify_transaction(transaction['buyer'], transaction['seller'], price)
+          notify_transaction(transaction['buyer'], transaction['seller'], transaction['price'])
         else
           response.reply_privately(
             "@#{user.mention_name}, #{t(:selling_lunch, price: price)}"

--- a/lib/lita/services/market_manager.rb
+++ b/lib/lita/services/market_manager.rb
@@ -41,9 +41,12 @@ module Lita
         @redis.srem('orders', order.to_json)
       end
 
-      def add_limit_order(new_order)
-        return if placed_limit_order?(JSON.parse(new_order)['user_id'])
-        @redis.sadd('orders', new_order)
+      def add_limit_order(user:, type:, created_at: Time.now)
+        new_order = build_new_order(user: user, type: type, created_at: created_at)
+        return if placed_limit_order?(new_order[:user_id])
+
+        @redis.sadd('orders', new_order.to_json)
+        new_order
       end
 
       def placed_limit_order?(user_id)
@@ -80,6 +83,17 @@ module Lita
 
       def transaction_possible?
         ask_orders.any? && bid_orders.any?
+      end
+
+      private
+
+      def build_new_order(user:, type:, created_at:)
+        {
+          id: SecureRandom.uuid,
+          user_id: user.id,
+          type: type,
+          created_at: created_at
+        }
       end
     end
   end

--- a/lib/lita/services/market_manager.rb
+++ b/lib/lita/services/market_manager.rb
@@ -19,18 +19,24 @@ module Lita
               .sort { |x, y| Time.parse(x['created_at']) <=> Time.parse(y['created_at']) }
       end
 
+      def order_criteria(order1, order2, order_type)
+        factor = order_type == :ask ? 1 : -1
+        [factor * order1['price'], Time.parse(order1['created_at'])] <=>
+          [factor * order2['price'], Time.parse(order2['created_at'])]
+      end
+
       def ask_orders
         orders = @redis.smembers('orders') || []
         orders.map { |order| JSON.parse(order) }
               .select { |z| z['type'] == 'ask' }
-              .sort { |x, y| Time.parse(x['created_at']) <=> Time.parse(y['created_at']) }
+              .sort { |x, y| order_criteria(x, y, :ask) }
       end
 
       def bid_orders
         orders = @redis.smembers('orders') || []
         orders.map { |order| JSON.parse(order) }
               .select { |z| z['type'] == 'bid' }
-              .sort { |x, y| Time.parse(x['created_at']) <=> Time.parse(y['created_at']) }
+              .sort { |x, y| order_criteria(x, y, :bid) }
       end
 
       def find_order(type, user_id)
@@ -55,18 +61,31 @@ module Lita
         orders.map { |order| order['user_id'] }.include? user_id
       end
 
-      def remove_orders
-        new_ask_orders = ask_orders
-        new_bid_orders = bid_orders
-        return if new_ask_orders.empty? || new_bid_orders.empty?
+      def pop_matching_orders
+        temp_ask_orders = ask_orders
+        temp_bid_orders = bid_orders
+        return if temp_ask_orders.empty? || temp_bid_orders.empty?
+
+        matches = matching_orders
+        return unless matches
+
         reset_limit_orders
-        new_ask_orders[1..-1].each do |order|
-          @redis.sadd('orders', order.to_json)
+        temp_ask_orders.reject { |ask| ask['id'] == matches['ask']['id'] }
+                       .each { |order| @redis.sadd('orders', order.to_json) }
+        temp_bid_orders.reject { |bid| bid['id'] == matches['bid']['id'] }
+                       .each { |order| @redis.sadd('orders', order.to_json) }
+        matches
+      end
+
+      def matching_orders
+        ask_orders.each do |ask_order|
+          bid_orders.each do |bid_order|
+            next if ask_order['price'] > bid_order['price']
+
+            return { 'ask' => ask_order, 'bid' => bid_order }
+          end
         end
-        new_bid_orders[1..-1].each do |order|
-          @redis.sadd('orders', order.to_json)
-        end
-        { 'ask' => new_ask_orders.first, 'bid' => new_bid_orders.first }
+        nil
       end
 
       def reset_limit_orders
@@ -75,22 +94,26 @@ module Lita
 
       def execute_transaction
         return unless transaction_possible?
-        executed_orders = remove_orders
+
+        executed_orders = pop_matching_orders
+        return unless executed_orders
+
         lunch_seller = Lita::User.find_by_id(executed_orders['ask']['user_id'])
         lunch_buyer = Lita::User.find_by_id(executed_orders['bid']['user_id'])
-        @karmanager.transfer_karma(lunch_buyer.id, lunch_seller.id, 1)
+        @karmanager.transfer_karma(lunch_buyer.id, lunch_seller.id, executed_orders['ask']['price'])
         @lunch_assigner.transfer_lunch(lunch_seller.mention_name, lunch_buyer.mention_name)
         {
           'buyer' => lunch_buyer,
           'seller' => lunch_seller,
           'timestamp' => Time.now,
           'bid_order' => executed_orders['bid'],
-          'ask_order' => executed_orders['ask']
+          'ask_order' => executed_orders['ask'],
+          'price' => executed_orders['ask']['price']
         }
       end
 
       def transaction_possible?
-        ask_orders.any? && bid_orders.any?
+        matching_orders.present?
       end
 
       private

--- a/lib/lita/services/market_manager.rb
+++ b/lib/lita/services/market_manager.rb
@@ -41,8 +41,10 @@ module Lita
         @redis.srem('orders', order.to_json)
       end
 
-      def add_limit_order(user:, type:, created_at: Time.now)
-        new_order = build_new_order(user: user, type: type, created_at: created_at)
+      def add_limit_order(user:, type:, created_at: Time.now, price: 1)
+        new_order = build_new_order(
+          user: user, type: type, created_at: created_at, price: price
+        )
         return if placed_limit_order?(new_order[:user_id])
 
         @redis.sadd('orders', new_order.to_json)
@@ -93,12 +95,13 @@ module Lita
 
       private
 
-      def build_new_order(user:, type:, created_at:)
+      def build_new_order(user:, type:, created_at:, price:)
         {
           id: SecureRandom.uuid,
           user_id: user.id,
           type: type,
-          created_at: created_at
+          created_at: created_at,
+          price: price
         }
       end
     end

--- a/lib/lita/services/market_manager.rb
+++ b/lib/lita/services/market_manager.rb
@@ -78,7 +78,13 @@ module Lita
         lunch_buyer = Lita::User.find_by_id(executed_orders['bid']['user_id'])
         @karmanager.transfer_karma(lunch_buyer.id, lunch_seller.id, 1)
         @lunch_assigner.transfer_lunch(lunch_seller.mention_name, lunch_buyer.mention_name)
-        executed_orders
+        {
+          'buyer' => lunch_buyer,
+          'seller' => lunch_seller,
+          'timestamp' => Time.now,
+          'bid_order' => executed_orders['bid'],
+          'ask_order' => executed_orders['ask']
+        }
       end
 
       def transaction_possible?

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -40,6 +40,8 @@ en:
         announce_count: '%{subject1} la cuenta de almuerzos en %{month} fue: Platanus: %{count1}, Fintual: %{count2}, Buda: %{count3}'
         food_delivery: 'Pizza? Subway? Mechada? Vean que quieren pedir!'
         food_delivery_link: 'Te incluí aquí https://platanus.slack.com/archives/%{channel_code}/p%{timestamp} para que veas que pedir con los demás hambrientos'
+        order_book_entry: "%{user} %{action} %{price}"
+        order_book: ":chart_with_upwards_trend: Libro de ordenes\nVendiendo :arrow_down:\n%{ask_entries}\n-----------------\n%{bid_entries}\nComprando :arrow_up:"
         help:
           thanks:
             usage: gracias
@@ -89,3 +91,6 @@ en:
           want_delivery:
             usage: quiero pedir
             description: Incluirme en un thread para quienes quieren pedir delivery
+          order_book:
+            usage: cómo está el mercado
+            description: Muestra el libro de ordenes actual

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -30,11 +30,11 @@ en:
         wont_lunch: "Aun no se distinguir entre los que no han contestado y los que contestaron que no, pero aquí van los que no contestaron que sí: %{subject}"
         dinner_is_served: "Está listo amiguito, *suba* a almorzar ;)"
         friend_added: "Perfecto @%{subject}, anoté a tu invitado como invitado_de_%{subject}."
-        selling_lunch: 'tengo tu almuerzo en venta!'
-        buying_lunch: 'voy a tratar de conseguirte almuerzo!'
+        selling_lunch: 'tengo tu almuerzo en venta a %{price} karma/s!'
+        buying_lunch: 'voy a tratar de conseguirte almuerzo a %{price} karma/s!'
         bought_lunch: 'ya te conseguí almuerzo!'
         sold_lunch: 'ya te vendí almuerzo!'
-        transaction: "@%{subject1} le compró almuerzo a @%{subject2}"
+        transaction: "@%{subject1} le compró almuerzo a @%{subject2} a %{price} karma/s"
         cant_buy: 'no te puedo comprar almuerzo...'
         cant_sell: 'no puedes vender algo que no tienes!'
         announce_count: '%{subject1} la cuenta de almuerzos en %{month} fue: Platanus: %{count1}, Fintual: %{count2}, Buda: %{count3}'

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -46,6 +46,8 @@ en:
         food_delivery_link: 'Te incluí aquí https://platanus.slack.com/archives/%{channel_code}/p%{timestamp} para que veas que pedir con los demás hambrientos'
         karma_list_entry: '@%{mention_name} tiene %{karma}'
         karma_list: ":frog: aquí va la lista de :karma::\n%{entries}"
+        order_book_entry: "%{user} %{action} %{price}"
+        order_book: ":chart_with_upwards_trend: Libro de ordenes\nVendiendo :arrow_down:\n%{ask_entries}\n-----------------\n%{bid_entries}\nComprando :arrow_up:"
         help:
           thanks:
             usage: gracias
@@ -104,3 +106,6 @@ en:
           karma_list:
             usage: show me the money
             description: Pedir listado de karma de todos los almorzadores
+          order_book:
+            usage: cómo está el mercado
+            description: Muestra el libro de ordenes actual

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -30,15 +30,15 @@ en:
         wont_lunch: "Aun no se distinguir entre los que no han contestado y los que contestaron que no, pero aquí van los que no contestaron que sí: %{subject}"
         dinner_is_served: "Está listo amiguito, *suba* a almorzar ;)"
         friend_added: "Perfecto @%{subject}, anoté a tu invitado como invitado_de_%{subject}."
-        selling_lunch: 'tengo tu almuerzo en venta!'
+        selling_lunch: 'tengo tu almuerzo en venta a %{price} karma/s!'
         selling_lunch_cancelled: 'ya no venderé tu almuerzo'
         not_selling_lunch: 'Nunca estuviste vendiendo :unamused:'
-        buying_lunch: 'voy a tratar de conseguirte almuerzo!'
+        buying_lunch: 'voy a tratar de conseguirte almuerzo a %{price} karma/s!'
         buying_lunch_cancelled: 'ya no te conseguiré almuerzo'
         not_buying_lunch: 'Nunca estuviste comprando :unamused:'
         bought_lunch: 'ya te conseguí almuerzo!'
         sold_lunch: 'ya te vendí almuerzo!'
-        transaction: "@%{subject1} le compró almuerzo a @%{subject2}"
+        transaction: "@%{subject1} le compró almuerzo a @%{subject2} a %{price} karma/s"
         cant_buy: 'no te puedo comprar almuerzo...'
         cant_sell: 'no puedes vender algo que no tienes!'
         announce_count: '%{subject1} la cuenta de almuerzos en %{month} fue: Platanus: %{count1}, Fintual: %{count2}, Buda: %{count3}'

--- a/spec/lita/handlers/api/market_spec.rb
+++ b/spec/lita/handlers/api/market_spec.rb
@@ -11,17 +11,6 @@ describe Lita::Handlers::Api::Market, lita_handler: true do
   let(:ask_order) { { id: order_id, user_id: 127, type: 'ask', created_at: time } }
   let(:bid_order) { { id: order_id, user_id: 127, type: 'bid', created_at: time } }
 
-  def add_limit_order(order_id, user, type, created_at)
-    order = {
-      id: order_id,
-      user_id: user.id,
-      type: type,
-      created_at: created_at
-    }.to_json
-    market.add_limit_order(order)
-    order
-  end
-
   it { is_expected.to route_http(:get, 'market/limit_orders') }
   it { is_expected.to route_http(:post, 'market/limit_orders') }
 
@@ -122,11 +111,16 @@ describe Lita::Handlers::Api::Market, lita_handler: true do
               res.params['type'] = 'ask'
               res.body = ask_order.to_json
             end.body)
-            order = JSON.parse(response['order'])
-            expect(order).not_to be_nil
-            expect(order['id']).not_to be_nil
-            expect(order['type']).to eq('ask')
-            expect(order['created_at']).not_to be_nil
+            expect(response['order']).not_to be_nil
+          end
+
+          it 'calls MarketManager#add_limit_order' do
+            http.post do |res|
+              res.url 'market/limit_orders'
+              res.params['type'] = 'ask'
+              res.body = ask_order.to_json
+            end
+            expect(market).to have_received(:add_limit_order).with(user: user, type: 'ask')
           end
 
           it "doesn't responds with executed_orders" do

--- a/spec/lita/handlers/lunch_reminder_spec.rb
+++ b/spec/lita/handlers/lunch_reminder_spec.rb
@@ -117,7 +117,8 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
             'buyer' => buyer,
             'seller' => seller,
             'ask_order' => ask_order,
-            'bid_order' => bid_order
+            'bid_order' => bid_order,
+            'price' => 1
           }
         end
         let(:lita_user) { Lita::User }
@@ -182,7 +183,7 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
       end
 
       context 'with transaction executed' do
-        let(:executed_tx) { { 'buyer' => buyer, 'seller' => seller } }
+        let(:executed_tx) { { 'buyer' => buyer, 'seller' => seller, 'price' => 12 } }
 
         it 'responds that tx was executed' do
           send_message('@lita vendo almuerzo a 12 karmas', as: seller)

--- a/spec/lita/handlers/lunch_reminder_spec.rb
+++ b/spec/lita/handlers/lunch_reminder_spec.rb
@@ -104,16 +104,21 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
       context 'one or more bid orders placed' do
         let(:ask_order) { { 'id' => 1111, 'user_id' => 124, 'type' => 'ask' } }
         let(:bid_order) { { 'id' => 2222, 'user_id' => 123, 'type' => 'bid' } }
-        let(:orders) { { 'ask' => ask_order, 'bid' => bid_order } }
-        let(:user) { double(mention_name: 'felipe.dominguez') }
+        let(:orders) do
+          {
+            'buyer' => user,
+            'seller' => user2,
+            'ask_order' => ask_order,
+            'bid_order' => bid_order
+          }
+        end
         let(:lita_user) { Lita::User }
-        let!(:user2) { Lita::User.create(124, mention_name: 'armando') }
+        let(:user) { Lita::User.create(123, mention_name: 'felipe.dominguez') }
+        let(:user2) { Lita::User.create(124, mention_name: 'armando') }
+
         before do
           allow_any_instance_of(Lita::Services::MarketManager).to \
             receive(:execute_transaction).and_return(orders)
-          allow(lita_user).to receive(:find_by_id).with(123).and_return(user)
-          allow(lita_user).to receive(:find_by_id).with(124).and_return(user2)
-          allow(lita_user).to receive(:create).and_return(user2)
         end
 
         it 'responds with transaction' do
@@ -168,23 +173,27 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
       end
 
       context 'one or more ask orders placed' do
-        let(:ask_order) { { 'id' => 1111, 'user_id' => 123, 'type' => 'ask' } }
-        let(:bid_order) { { 'id' => 2222, 'user_id' => 124, 'type' => 'bid' } }
-        let(:orders) { { 'ask' => ask_order, 'bid' => bid_order } }
-        let(:user) { double(mention_name: 'felipe.dominguez') }
+        let(:ask_order) { { 'id' => 1111, 'user_id' => seller.id, 'type' => 'ask' } }
+        let(:bid_order) { { 'id' => 2222, 'user_id' => buyer.id, 'type' => 'bid' } }
+        let(:orders) do
+          {
+            'ask_order' => ask_order,
+            'bid_order' => bid_order,
+            'buyer' => buyer,
+            'seller' => seller
+          }
+        end
         let(:lita_user) { Lita::User }
-        let!(:user2) { Lita::User.create(124, mention_name: 'armando') }
+        let(:seller) { Lita::User.create(123, mention_name: 'felipe.dominguez') }
+        let(:buyer) { Lita::User.create(124, mention_name: 'armando') }
+
         before do
           allow_any_instance_of(Lita::Services::MarketManager).to \
             receive(:execute_transaction).and_return(orders)
-          allow(lita_user).to receive(:find_by_id).with(123).and_return(user)
-          allow(lita_user).to receive(:find_by_id).with(124).and_return(user2)
-          allow(lita_user).to receive(:create).and_return(user2)
         end
 
         it 'responds with transaction' do
-          armando = Lita::User.create(124, mention_name: 'armando')
-          send_message('@lita compro almuerzo', as: armando)
+          send_message('@lita compro almuerzo', as: buyer)
           expect(replies.last).to match('@armando le compró almuerzo a @felipe.dominguez')
         end
       end

--- a/spec/lita/handlers/lunch_reminder_spec.rb
+++ b/spec/lita/handlers/lunch_reminder_spec.rb
@@ -362,4 +362,51 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
       end
     end
   end
+
+  describe 'order book message' do
+    let(:seller) { Lita::User.create(125, mention_name: 'seller') }
+    let(:buyer) { Lita::User.create(126, mention_name: 'buyer') }
+
+    context 'with no orders' do
+      it 'responds with tumbleweeds' do
+        send_message('@lita cómo está el mercado', as: seller)
+        expect(replies.last).to(
+          match(
+            ":chart_with_upwards_trend: Libro de ordenes\n" +
+            "Vendiendo :arrow_down:\n" +
+            ":tumbleweed:\n" +
+            "-----------------\n" +
+            ":tumbleweed:\n" +
+            "Comprando :arrow_up:"
+          )
+        )
+      end
+    end
+
+    context 'with orders' do
+      let(:ask_orders) { [{ 'id' => 1111, 'user_id' => seller.id, 'type' => 'ask', 'price' => 2 }] }
+      let(:bid_orders) { [{ 'id' => 2222, 'user_id' => buyer.id, 'type' => 'bid', 'price' => 1 }] }
+      let(:market) { double }
+
+      before do
+        allow(Lita::Services::MarketManager).to receive(:new).and_return(market)
+        allow(market).to receive(:ask_orders).and_return(ask_orders)
+        allow(market).to receive(:bid_orders).and_return(bid_orders)
+      end
+
+      it 'responds with the order book' do
+        send_message('@lita cómo está el mercado', as: seller)
+        expect(replies.last).to(
+          match(
+            ":chart_with_upwards_trend: Libro de ordenes\n" +
+            "Vendiendo :arrow_down:\n" +
+            "seller vendiendo a 2\n" +
+            "-----------------\n" +
+            "buyer comprando a 1\n" +
+            "Comprando :arrow_up:"
+          )
+        )
+      end
+    end
+  end
 end

--- a/spec/lita/services/market_manager_spec.rb
+++ b/spec/lita/services/market_manager_spec.rb
@@ -71,7 +71,6 @@ describe Lita::Services::MarketManager, lita: true do
       end
 
       it 'adds limit order' do
-        add_limit_order(order_id, fdom, 'ask', order_time)
         expect(subject.orders.last).not_to be_nil
       end
 
@@ -80,7 +79,8 @@ describe Lita::Services::MarketManager, lita: true do
         expect(subject.orders.last['user_id']).to eq(fdom.id)
         expect(subject.orders.last['id']).to eq(order_id)
         expect(subject.orders.last['type']).to eq('ask')
-        expect(subject.orders.last['created_at']).to eq(order_time.strftime('%F %T %z'))
+        last_order_created_at = Time.parse(subject.orders.last['created_at']).strftime('%F %T %z')
+        expect(last_order_created_at).to eq(order_time.strftime('%F %T %z'))
       end
     end
 

--- a/spec/lita/services/market_manager_spec.rb
+++ b/spec/lita/services/market_manager_spec.rb
@@ -264,8 +264,8 @@ describe Lita::Services::MarketManager, lita: true do
 
       it 'matchs the correct limit order' do
         orders = subject.execute_transaction
-        expect(orders['ask']['user_id']).to eq(andres.id)
-        expect(orders['bid']['user_id']).to eq(fdom.id)
+        expect(orders['ask_order']['user_id']).to eq(andres.id)
+        expect(orders['bid_order']['user_id']).to eq(fdom.id)
       end
 
       it 'remove order from limit orders' do


### PR DESCRIPTION
Viva el libre mercado!

Se permite vender y comprar a más de 1 karma. 

Los comandos:

- compro almuerzo a 3 karmas (y algunas variaciones)
- vendo almuerzo a 2 karmas (y algunas variaciones)

Situaciones:
- Si hay alguien vendiendo a 2, y alguien compra a 2, se ejecuta la transacción
- Si hay alguien vendiendo a 2, y alguien compra a 1, no se ejecuta transacción
- Si hay alguien vendiendo a 1, y alguien compra a 2, entonces SÍ se ejecuta una transacción pero al precio de venta (en este caso, a 1)
- Si hay 5 personas comprando a 1, y 1 persona comprando a 2, y alguien vende a 2, se ejecuta la transacción con la persona vendiendo a 2.
- Si hay 5 personas comprando a 2, y una persona vende a 2, se ejecuta la transacción con la persona que puso la orden primero.

### Falta

- Se dan casos raros con cómo está implementado ahora. Voy a tener que ordenar por fecha y precio las `ask_orders` y `bid_orders` para determinar las `matching_orders`