### PR TITLE
Fix lunch assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The following environment variables should be defined in your Lita instance:
 - QUIET_START_HOUR
 - QUIET_END_HOUR
 - ASK_CRON
-- WAIT_RESPONSES_SECONDS
+- ANNOUNCE_WINNERS_CRON
 - PERSIST_CRON
 - COUNTS_CRON
 - KARMA_LIST_CRON

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -455,6 +455,7 @@ module Lita
         end
         scheduler.cron(ENV['ANNOUNCE_WINNERS_CRON']) do
           @assigner.do_the_assignment
+          @market.reset_limit_orders
           announce_winners if @assigner.winning_lunchers_list.count >= MIN_LUNCHERS
         end
         scheduler.cron(ENV['PERSIST_CRON']) do

--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -452,10 +452,10 @@ module Lita
         scheduler = Rufus::Scheduler.new
         scheduler.cron(ENV['ASK_CRON']) do
           refresh
-          scheduler.in(ENV['WAIT_RESPONSES_SECONDS'].to_i) do
-            @assigner.do_the_assignment
-            announce_winners if @assigner.winning_lunchers_list.count >= MIN_LUNCHERS
-          end
+        end
+        scheduler.cron(ENV['ANNOUNCE_WINNERS_CRON']) do
+          @assigner.do_the_assignment
+          announce_winners if @assigner.winning_lunchers_list.count >= MIN_LUNCHERS
         end
         scheduler.cron(ENV['PERSIST_CRON']) do
           @assigner.persist_winning_lunchers


### PR DESCRIPTION
Se usa un `cron` (parece que el `in` funciona cuando quiere no más)
Se resetean las ordenes para evitar que se pongan antes del sorteo