### PR TITLE
fix(lunch-assigner-spec): avoid checking for exact winners

### DIFF
--- a/spec/lita/services/lunch_assigner_spec.rb
+++ b/spec/lita/services/lunch_assigner_spec.rb
@@ -110,6 +110,7 @@ describe Lita::Services::LunchAssigner, lita: true do
     expect(subject.get_karma(alfredo.mention_name)).to eq(100)
   end
 
+  # rubocop:disable RSpec/ExampleLength, RSpec/NamedSubject
   it "interates until every spot has been asigned" do
     subject.add_to_current_lunchers(alfredo.mention_name)
     subject.set_karma(alfredo.mention_name, 1)
@@ -122,10 +123,11 @@ describe Lita::Services::LunchAssigner, lita: true do
     subject.add_to_current_lunchers(juan.mention_name)
     subject.set_karma(juan.mention_name, 6)
     subject.pick_winners(2)
-    expect(subject.winning_lunchers_list).to include(pedro.mention_name)
-    expect(subject.winning_lunchers_list).to include(juan.mention_name)
+    candidates = [pedro.mention_name, juan.mention_name, alfredo.mention_name]
+    expect(candidates).to include(*subject.winning_lunchers_list)
     expect(subject.winning_lunchers_list.count).to eq(2)
   end
+  # rubocop:enable RSpec/ExampleLength, RSpec/NamedSubject
 
   describe '#pick_winners' do
     it 'allows for a single no karma man to win' do


### PR DESCRIPTION
El resultado de `pick_winners` tiene una componente no determinista, por lo que el test no debería chequear exactamente quienes son los ganadores