### PR TITLE
feat(handlers/lunch_reminders): flexibilize transfer command

### DIFF
--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -164,17 +164,19 @@ module Lita
         response.reply("@#{user.mention_name} tiene #{user_karma} puntos de karma.")
       end
 
-      route(/transfi[ée]rele karma a ([^\s]+)/i, command: true) do |response|
+      route(/(transfi[ée]r|d|su[ée]lt|p[áa]s)[ae]le (\d*)( ?karmas?)? a ([^\s]+)/i,
+        command: true) do |response|
         giver = response.user
-        mention_name = clean_mention_name(response.matches[0][0])
+        amount = [response.matches[0][1].to_i, 1].max
+        mention_name = clean_mention_name(response.matches[0][-1])
         destinatary = Lita::User.find_by_mention_name(mention_name)
-        transfered = @karmanager.transfer_karma(giver.id, destinatary.id, 1)
+        transfered = @karmanager.transfer_karma(giver.id, destinatary.id, amount)
         if transfered
           response.reply(
-            "@#{giver.mention_name}, le has dado uno de tus puntos de " +
+            "@#{giver.mention_name}, le has dado #{amount} de tus puntos de " +
             "karma a @#{destinatary.mention_name}."
           )
-          broadcast_to_channel("@#{giver.mention_name}, le ha dado un punto de " +
+          broadcast_to_channel("@#{giver.mention_name}, le ha dado #{amount} punto/s de " +
             "karma a @#{destinatary.mention_name}.", KARMA_AUDIT_CHANNEL)
         else
           response.reply(

--- a/spec/lita/handlers/lunch_reminder_spec.rb
+++ b/spec/lita/handlers/lunch_reminder_spec.rb
@@ -63,7 +63,7 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
         armando = Lita::User.create(124, mention_name: 'armando')
         jilberto = Lita::User.create(125, mention_name: 'jilberto')
         send_message('@lita transfierele karma a armando', as: jilberto)
-        expect(replies.last).to match('@jilberto, le ha dado un punto de karma a @armando.')
+        expect(replies.last).to match('@jilberto, le ha dado 1 punto/s de karma a @armando.')
       end
     end
 


### PR DESCRIPTION
Este PR tiene dos objetivos:

1) Hacer que se pueda transferir más de un karma con un solo comando

2) Hacer que sea más fácil dar karma. Todas estas variantes serían aceptadas:
- suéltale 84 karma a pepin
- dale 10 a juan
- pasale 23 karmas a cholito
- transfierele karma a jose