### PR TITLE
fix(transaction): fix transaction message giving wrong price

### DIFF
--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -249,7 +249,7 @@ module Lita
         end
         next unless @market.add_limit_order(user: user, type: 'bid', price: price)
         if transaction = @market.execute_transaction
-          notify_transaction(transaction['buyer'], transaction['seller'], price)
+          notify_transaction(transaction['buyer'], transaction['seller'], transaction['price'])
         else
           response.reply_privately(
             "@#{user.mention_name}, #{t(:buying_lunch, price: price)}"

--- a/spec/lita/handlers/lunch_reminder_spec.rb
+++ b/spec/lita/handlers/lunch_reminder_spec.rb
@@ -302,11 +302,11 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
       end
 
       context 'with transaction executed' do
-        let(:executed_tx) { { 'buyer' => buyer, 'seller' => seller } }
+        let(:executed_tx) { { 'buyer' => buyer, 'seller' => seller, 'price' => 1 } }
 
         it 'responds that tx was executed' do
           send_message('@lita compro almuerzo a 12 karmas', as: buyer)
-          expect(replies.last).to match('@armando le compró almuerzo a @jorge a 12 karma/s')
+          expect(replies.last).to match('@armando le compró almuerzo a @jorge a 1 karma/s')
         end
 
         it 'calls add_limit_order' do


### PR DESCRIPTION
## Contexto

Al haber una transacción en que el comprador ofrecía más que el vendedor, esta se realizaba al precio de venta pero la notificación de slack se hacía al precio de compra.

## Solución
Se cambió la notificación de slack usando el precio salido de la transacción.