### PR TITLE
Feat: cant sell lunch for more than max karma

### DIFF
--- a/lib/lita/handlers/lunch_reminder.rb
+++ b/lib/lita/handlers/lunch_reminder.rb
@@ -215,6 +215,10 @@ module Lita
           response.reply("@#{user.mention_name} #{t(:cant_sell)}")
           next
         end
+        unless price == 1 || (@karmanager.get_karma(user.id) + price) < ENV.fetch('KARMA_LIMIT', 50).to_i
+          price = 1
+          response.reply("@#{user.mention_name} #{t(:cant_sell_high_price)}")
+        end
         next unless @market.add_limit_order(user: user, type: 'ask', price: price)
         if transaction = @market.execute_transaction
           notify_transaction(transaction['buyer'], transaction['seller'], transaction['price'])

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -41,6 +41,7 @@ en:
         transaction: "@%{subject1} le compró almuerzo a @%{subject2} a %{price} karma/s"
         cant_buy: 'no te puedo comprar almuerzo...'
         cant_sell: 'no puedes vender algo que no tienes!'
+        cant_sell_high_price: 'tienes el máximo de karma :chang: Voy a poner tu almuerzo a 1!'
         announce_count: '%{subject1} la cuenta de almuerzos en %{month} fue: Platanus: %{count1}, Fintual: %{count2}, Buda: %{count3}'
         food_delivery: 'Pizza? Subway? Mechada? Vean que quieren pedir!'
         food_delivery_link: 'Te incluí aquí https://platanus.slack.com/archives/%{channel_code}/p%{timestamp} para que veas que pedir con los demás hambrientos'

--- a/spec/lita/handlers/lunch_reminder_spec.rb
+++ b/spec/lita/handlers/lunch_reminder_spec.rb
@@ -144,6 +144,26 @@ describe Lita::Handlers::LunchReminder, lita_handler: true do
           )
         end
       end
+
+      context 'when seller has max karma' do
+        let(:market) { double }
+        let(:seller) { Lita::User.create(124, mention_name: 'armando') }
+
+        before do
+          allow(Lita::Services::MarketManager).to receive(:new).and_return(market)
+          allow(market).to receive(:add_limit_order).and_return(true)
+          allow(market).to receive(:execute_transaction).and_return(false)
+          allow_any_instance_of(Lita::Services::Karmanager).to\
+            receive(:get_karma).with(seller.id).and_return(1000)
+        end
+
+        it 'sets order to 1' do
+          send_message('@lita vendo almuerzo a 2', as: seller)
+          expect(market).to(
+            have_received(:add_limit_order).with(user: seller, type: 'ask', price: 1)
+          )
+        end
+      end
     end
 
     context 'user without lunch' do


### PR DESCRIPTION
Se restringió que para poder vender a más de 1 hay que tener menos que el karma máximo.
